### PR TITLE
Fix circleci setup, add readme badges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ workflows:
 
 erlang-test-steps: &erlang-test-steps
   steps:
+    - run:
+        name: install units
+        command: sudo apt install units
     - checkout:
         path: ~/repo
     - run:
@@ -24,8 +27,8 @@ jobs:
   test-23:
     <<: *erlang-test-steps
     docker:
-      - image: circleci/erlang:23.0
+      - image: circleci/erlang:23
   test-24:
     <<: *erlang-test-steps
     docker:
-      - image: circleci/erlang:24.0
+      - image: circleci/erlang:24

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # rinseweb
 
+![CircleCI](https://img.shields.io/circleci/build/github/RinseOne/rinseweb?style=for-the-badge)
+![GitHub](https://img.shields.io/github/license/RinseOne/rinseweb?style=for-the-badge)
+
 Web application for providing answers using configured backends written in Erlang/OTP.
 
 ## Prerequisites


### PR DESCRIPTION
Now uses correct CircleCI docker image tags so checks pass, and adds fancy badge to the top of the readme.