### PR TITLE
Handle conformability error, weight fixes, add fluid oz

### DIFF
--- a/src/rinseweb_wiz_convert.erl
+++ b/src/rinseweb_wiz_convert.erl
@@ -13,7 +13,7 @@
     % weight
     mg | g | kg | pound | ounce
     % volume
-    | ml | liter | kiloliter | quart | gallon | cc
+    | ml | liter | kiloliter | quart | gallon | cc | floz
     % bandwidth
     | bit | byte | kilobit | kilobyte | megabit | megabyte | gigabit | gigabyte
     % distance
@@ -121,6 +121,8 @@ binary_to_canonical_unit(<<"g">>) -> g;
 binary_to_canonical_unit(<<"kilogram">>) -> kg;
 binary_to_canonical_unit(<<"kilograms">>) -> kg;
 binary_to_canonical_unit(<<"kg">>) -> kg;
+binary_to_canonical_unit(<<"lb">>) -> pound;
+binary_to_canonical_unit(<<"lbs">>) -> pound;
 binary_to_canonical_unit(<<"pound">>) -> pound;
 binary_to_canonical_unit(<<"pounds">>) -> pound;
 binary_to_canonical_unit(<<"ounce">>) -> ounce;
@@ -130,7 +132,10 @@ binary_to_canonical_unit(<<"oz">>) -> ounce;
 binary_to_canonical_unit(<<"milliliter">>) -> ml;
 binary_to_canonical_unit(<<"milliliters">>) -> ml;
 binary_to_canonical_unit(<<"ml">>) -> ml;
+binary_to_canonical_unit(<<"l">>) -> liter;
 binary_to_canonical_unit(<<"liter">>) -> liter;
+binary_to_canonical_unit(<<"liters">>) -> liter;
+binary_to_canonical_unit(<<"kl">>) -> kiloliter;
 binary_to_canonical_unit(<<"kiloliter">>) -> kiloliter;
 binary_to_canonical_unit(<<"kiloliters">>) -> kiloliter;
 binary_to_canonical_unit(<<"quart">>) -> quart;
@@ -140,6 +145,10 @@ binary_to_canonical_unit(<<"qts">>) -> quart;
 binary_to_canonical_unit(<<"gallon">>) -> gallon;
 binary_to_canonical_unit(<<"gallons">>) -> gallon;
 binary_to_canonical_unit(<<"cc">>) -> cc;
+binary_to_canonical_unit(<<"floz">>) -> floz;
+binary_to_canonical_unit(<<"fluid oz">>) -> floz;
+binary_to_canonical_unit(<<"fluid ounce">>) -> floz;
+binary_to_canonical_unit(<<"fluid ounces">>) -> floz;
 % bandwidth
 binary_to_canonical_unit(<<"bit">>) -> bit;
 binary_to_canonical_unit(<<"bits">>) -> bit;
@@ -201,6 +210,8 @@ canonical_unit_to_binary(_, kg) -> <<"kilograms">>;
 % volume
 canonical_unit_to_binary(_, ml) -> <<"ml">>;
 canonical_unit_to_binary(_, cc) -> <<"cc">>;
+canonical_unit_to_binary(1, floz) -> <<"fluid ounce">>;
+canonical_unit_to_binary(_, floz) -> <<"fluid ounces">>;
 % bandwidth
 % distance
 canonical_unit_to_binary(1, mm) -> <<"millimeter">>;

--- a/src/rinseweb_wiz_convert.erl
+++ b/src/rinseweb_wiz_convert.erl
@@ -100,6 +100,7 @@ binary_to_number(B) ->
 
 -spec string_to_number(string()) -> number() | undefined.
 string_to_number([]) -> undefined;
+string_to_number("conformability error") -> undefined;
 string_to_number(S) ->
     case string:to_float(S) of
         {error, no_float} -> list_to_integer(S);

--- a/test/convert_SUITE.erl
+++ b/test/convert_SUITE.erl
@@ -41,20 +41,26 @@ end_per_testcase(_, _Config) ->
 
 unit_coverage(_) ->
     TestCases = [
+        % weight
         {<<"1">>, <<"g">>, <<"mg">>, <<"1 gram is equal to 1000 milligrams">>},
         {<<"1">>, <<"kg">>, <<"g">>, <<"1 kilogram is equal to 1000 grams">>},
         {<<"1">>, <<"pound">>, <<"ounce">>, <<"1 pound is equal to 16 ounces">>},
+        % volume
         {<<"1">>, <<"liter">>, <<"ml">>, <<"1 liter is equal to 1000 ml">>},
         {<<"1">>, <<"kiloliter">>, <<"cc">>, <<"1 kiloliter is equal to 1000000 cc">>},
         {<<"1">>, <<"gallon">>, <<"qt">>, <<"1 gallon is equal to 4 quarts">>},
+        {<<"1">>, <<"gallon">>, <<"floz">>, <<"1 gallon is equal to 128 fluid ounces">>},
+        % bandwidth
         {<<"1">>, <<"byte">>, <<"bit">>, <<"1 byte is equal to 8 bits">>},
         {<<"1">>, <<"kb">>, <<"kilobit">>, <<"1 kilobyte is equal to 8 kilobits">>},
         {<<"1">>, <<"mb">>, <<"megabit">>, <<"1 megabyte is equal to 8 megabits">>},
         {<<"1">>, <<"gb">>, <<"gigabit">>, <<"1 gigabyte is equal to 8 gigabits">>},
         {<<"1">>, <<"cm">>, <<"mm">>, <<"1 centimeter is equal to 10 millimeters">>},
         {<<"1">>, <<"km">>, <<"m">>, <<"1 kilometer is equal to 1000 meters">>},
+        % distance
         {<<"1">>, <<"mile">>, <<"yard">>, <<"1 mile is equal to 1760 yards">>},
         {<<"1">>, <<"foot">>, <<"inch">>, <<"1 foot is equal to 12 inches">>},
+        % temperature
         {<<"1">>, <<"celsius">>, <<"fahrenheit">>, <<"1 celsius is equal to 33.8 fahrenheit">>}
     ],
     F = fun({UnitNum, UnitFrom, UnitTo, ExpectedShort}, Acc) ->
@@ -73,7 +79,8 @@ unit_invalid(_) ->
     TestCases = [
         {<<"kg">>, <<"foo">>},
         {<<"foo">>, <<"kg">>},
-        {<<"foo">>, <<"bar">>}
+        {<<"foo">>, <<"bar">>},
+        {<<"kg">>, <<"mm">>}
     ],
     UnitNum = <<"1">>,
     F = fun({UnitFrom, UnitTo}, Acc) ->


### PR DESCRIPTION
## Description

* Adds handling for "conformability error" when the conversion between specified units is undefined, e.g. convert kg to mm
* Adds few weight aliases `l`, `kl`, `liters`, `lb`, `lbs`
* Adds fluid ounces volume unit