### PR TITLE
Rework convert wizard to allow most units

### DIFF
--- a/src/rinseweb_manifests.erl
+++ b/src/rinseweb_manifests.erl
@@ -33,7 +33,7 @@ get_all() ->
             matches => [
                 #{
                     type => regex,
-                    value => <<"^convert ([-]?[0-9]*[.]?[0-9]+)\s*([^0-9.]+) to (.*)$">>
+                    value => <<"^convert ([-]?[0-9]*[.]?[0-9]+)\s*([a-zA-Z]+)\s+to\s+([a-zA-Z]+)$">>
                 }
             ],
             handler => rinseweb_wiz_convert

--- a/src/rinseweb_wiz_convert.erl
+++ b/src/rinseweb_wiz_convert.erl
@@ -9,19 +9,8 @@
 -export([answer/2]).
 
 %% Types
--type unit() ::
-    % weight
-    mg | g | kg | pound | ounce
-    % volume
-    | ml | liter | kiloliter | quart | gallon | cc | floz
-    % bandwidth
-    | bit | byte | kilobit | kilobyte | megabit | megabyte | gigabit | gigabyte
-    % distance
-    | mm | cm | m | km | inch | foot | yard | mile
-    % temperature
-    | tempC | tempF
-    % default
-    | unknown.
+-type unit_or_unknown() :: binary() | unknown.
+-type unit() :: binary().
 
 %%====================================================================
 %% API
@@ -37,22 +26,20 @@ answer(Question, [FromNumBin, FromUnitBin, ToUnitBin]) ->
 %% Internal functions
 %%====================================================================
 
--spec answer_using_canonical_units(rinseweb_wiz:question(), binary(), unit(), unit()) -> rinseweb_wiz:answer().
+-spec answer_using_canonical_units(rinseweb_wiz:question(), binary(), unit_or_unknown(), unit_or_unknown()) -> rinseweb_wiz:answer().
 answer_using_canonical_units(_, _, unknown, _) -> shrug;
 answer_using_canonical_units(_, _, _, unknown) -> shrug;
 answer_using_canonical_units(Question, FromNumBin, FromUnit, ToUnit) ->
     FromNum = round_precise(binary_to_number(FromNumBin)),
     ConversionResult = convert(FromNum, FromUnit, ToUnit),
-    answer_conversion_result(Question, FromNumBin, FromNum, FromUnit, ToUnit, ConversionResult).
+    answer_conversion_result(Question, FromNumBin, FromUnit, ToUnit, ConversionResult).
 
--spec answer_conversion_result(rinseweb_wiz:question(), binary(), number(), unit(), unit(), number()) -> rinseweb_wiz:answer().
-answer_conversion_result(_, _, _, _, _, undefined) -> shrug;
-answer_conversion_result(Question, FromNumBin, FromNum, FromUnit, ToUnit, ConversionResult) ->
+-spec answer_conversion_result(rinseweb_wiz:question(), binary(), unit(), unit(), number()) -> rinseweb_wiz:answer().
+answer_conversion_result(_, _, _, _, undefined) -> shrug;
+answer_conversion_result(Question, FromNumBin, FromUnit, ToUnit, ConversionResult) ->
     ToNum = round_precise(ConversionResult),
     ToBin = number_to_binary(ToNum),
-    ToUnitBin = canonical_unit_to_binary(ToNum, ToUnit),
-    FromUnitBin = canonical_unit_to_binary(FromNum, FromUnit),
-    Answer = <<FromNumBin/binary, " ", FromUnitBin/binary, " is equal to ", ToBin/binary, " ", ToUnitBin/binary>>,
+    Answer = <<FromNumBin/binary, " ", FromUnit/binary, " = ", ToBin/binary, " ", ToUnit/binary>>,
     #{
         question => Question,
         type => text,
@@ -61,21 +48,24 @@ answer_conversion_result(Question, FromNumBin, FromNum, FromUnit, ToUnit, Conver
 
 -spec convert(number(), unit(), unit()) -> number() | undefined.
 convert(Num, FromUnit, ToUnit) ->
-    Command = "units --strict",
+    Command = "units --terse",
     FromArg = units_from_arg(Num, FromUnit),
-    ToArg = " '" ++ atom_to_list(ToUnit) ++ "'",
+    ToArg = " '" ++ unit_arg(ToUnit) ++ "'",
     RawUnitsResult = os:cmd([Command, FromArg, ToArg]),
-    FirstLineTrimmed = string:trim(string:slice(RawUnitsResult, 0, string:str(RawUnitsResult, "\n"))),
-    % remove optional "* " from "* 123"
-    Answer = string:trim(FirstLineTrimmed, leading, "* "),
+    Answer = string:trim(string:slice(RawUnitsResult, 0, string:str(RawUnitsResult, "\n"))),
     string_to_number(Answer).
 
 -spec units_from_arg(number(), unit()) -> list().
-units_from_arg(Num, tempC) -> " 'tempC(" ++ number_to_list(Num) ++ ")'";
-units_from_arg(Num, tempF) -> " 'tempF(" ++ number_to_list(Num) ++ ")'";
+units_from_arg(Num, <<"celsius">>) -> " 'tempC(" ++ number_to_list(Num) ++ ")'";
+units_from_arg(Num, <<"fahrenheit">>) -> " 'tempF(" ++ number_to_list(Num) ++ ")'";
 units_from_arg(Num, Unit) ->
     % extra space to avoid treating negative numbers as CLI options
-    " ' " ++ number_to_list(Num) ++ " " ++ atom_to_list(Unit) ++ "'".
+    " ' " ++ number_to_list(Num) ++ " " ++ binary_to_list(Unit) ++ "'".
+
+-spec unit_arg(unit()) -> list().
+unit_arg(<<"celsius">>) -> "tempC";
+unit_arg(<<"fahrenheit">>) -> "tempF";
+unit_arg(UnitBin) when is_binary(UnitBin) -> binary_to_list(UnitBin).
 
 -spec round_precise(number()) -> number().
 round_precise(Num) when is_integer(Num) -> Num;
@@ -101,6 +91,7 @@ binary_to_number(B) ->
 -spec string_to_number(string()) -> number() | undefined.
 string_to_number([]) -> undefined;
 string_to_number("conformability error") -> undefined;
+string_to_number([$U,$n,$k,$n,$o,$w,$n|_]) -> undefined; % Handles "Unknown unit 'foo'" error
 string_to_number(S) ->
     case string:to_float(S) of
         {error, no_float} -> list_to_integer(S);
@@ -111,127 +102,14 @@ string_to_number(S) ->
 number_to_list(Num) when is_integer(Num) -> integer_to_list(Num);
 number_to_list(Num) when is_float(Num) -> float_to_list(Num, [{decimals, 10}, compact]).
 
--spec binary_to_canonical_unit(binary()) -> unit().
-% weight
-binary_to_canonical_unit(<<"milligram">>) -> mg;
-binary_to_canonical_unit(<<"milligrams">>) -> mg;
-binary_to_canonical_unit(<<"mg">>) -> mg;
-binary_to_canonical_unit(<<"gram">>) -> g;
-binary_to_canonical_unit(<<"grams">>) -> g;
-binary_to_canonical_unit(<<"g">>) -> g;
-binary_to_canonical_unit(<<"kilogram">>) -> kg;
-binary_to_canonical_unit(<<"kilograms">>) -> kg;
-binary_to_canonical_unit(<<"kg">>) -> kg;
-binary_to_canonical_unit(<<"lb">>) -> pound;
-binary_to_canonical_unit(<<"lbs">>) -> pound;
-binary_to_canonical_unit(<<"pound">>) -> pound;
-binary_to_canonical_unit(<<"pounds">>) -> pound;
-binary_to_canonical_unit(<<"ounce">>) -> ounce;
-binary_to_canonical_unit(<<"ounces">>) -> ounce;
-binary_to_canonical_unit(<<"oz">>) -> ounce;
-% volume
-binary_to_canonical_unit(<<"milliliter">>) -> ml;
-binary_to_canonical_unit(<<"milliliters">>) -> ml;
-binary_to_canonical_unit(<<"ml">>) -> ml;
-binary_to_canonical_unit(<<"l">>) -> liter;
-binary_to_canonical_unit(<<"liter">>) -> liter;
-binary_to_canonical_unit(<<"liters">>) -> liter;
-binary_to_canonical_unit(<<"kl">>) -> kiloliter;
-binary_to_canonical_unit(<<"kiloliter">>) -> kiloliter;
-binary_to_canonical_unit(<<"kiloliters">>) -> kiloliter;
-binary_to_canonical_unit(<<"quart">>) -> quart;
-binary_to_canonical_unit(<<"quarts">>) -> quart;
-binary_to_canonical_unit(<<"qt">>) -> quart;
-binary_to_canonical_unit(<<"qts">>) -> quart;
-binary_to_canonical_unit(<<"gallon">>) -> gallon;
-binary_to_canonical_unit(<<"gallons">>) -> gallon;
-binary_to_canonical_unit(<<"cc">>) -> cc;
-binary_to_canonical_unit(<<"floz">>) -> floz;
-binary_to_canonical_unit(<<"fluid oz">>) -> floz;
-binary_to_canonical_unit(<<"fluid ounce">>) -> floz;
-binary_to_canonical_unit(<<"fluid ounces">>) -> floz;
-% bandwidth
-binary_to_canonical_unit(<<"bit">>) -> bit;
-binary_to_canonical_unit(<<"bits">>) -> bit;
-binary_to_canonical_unit(<<"byte">>) -> byte;
-binary_to_canonical_unit(<<"bytes">>) -> byte;
-binary_to_canonical_unit(<<"kb">>) -> kilobyte;
-binary_to_canonical_unit(<<"kilobit">>) -> kilobit;
-binary_to_canonical_unit(<<"kilobits">>) -> kilobit;
-binary_to_canonical_unit(<<"kilobyte">>) -> kilobyte;
-binary_to_canonical_unit(<<"kilobytes">>) -> kilobyte;
-binary_to_canonical_unit(<<"megabit">>) -> megabit;
-binary_to_canonical_unit(<<"megabits">>) -> megabit;
-binary_to_canonical_unit(<<"mb">>) -> megabyte;
-binary_to_canonical_unit(<<"megabyte">>) -> megabyte;
-binary_to_canonical_unit(<<"megabytes">>) -> megabyte;
-binary_to_canonical_unit(<<"gigabit">>) -> gigabit;
-binary_to_canonical_unit(<<"gigabits">>) -> gigabit;
-binary_to_canonical_unit(<<"gb">>) -> gigabyte;
-binary_to_canonical_unit(<<"gigabyte">>) -> gigabyte;
-binary_to_canonical_unit(<<"gigabytes">>) -> gigabyte;
-% distance
-binary_to_canonical_unit(<<"millimeter">>) -> mm;
-binary_to_canonical_unit(<<"millimeters">>) -> mm;
-binary_to_canonical_unit(<<"mm">>) -> mm;
-binary_to_canonical_unit(<<"centimeter">>) -> cm;
-binary_to_canonical_unit(<<"centimeters">>) -> cm;
-binary_to_canonical_unit(<<"cm">>) -> cm;
-binary_to_canonical_unit(<<"meter">>) -> m;
-binary_to_canonical_unit(<<"meters">>) -> m;
-binary_to_canonical_unit(<<"m">>) -> m;
-binary_to_canonical_unit(<<"kilometer">>) -> km;
-binary_to_canonical_unit(<<"kilometers">>) -> km;
-binary_to_canonical_unit(<<"km">>) -> km;
-binary_to_canonical_unit(<<"in">>) -> inch;
-binary_to_canonical_unit(<<"inch">>) -> inch;
-binary_to_canonical_unit(<<"inches">>) -> inch;
-binary_to_canonical_unit(<<"foot">>) -> foot;
-binary_to_canonical_unit(<<"feet">>) -> foot;
-binary_to_canonical_unit(<<"yard">>) -> yard;
-binary_to_canonical_unit(<<"yards">>) -> yard;
-binary_to_canonical_unit(<<"mile">>) -> mile;
-binary_to_canonical_unit(<<"miles">>) -> mile;
-% temperature
-binary_to_canonical_unit(<<"c">>) -> tempC;
-binary_to_canonical_unit(<<"celsius">>) -> tempC;
-binary_to_canonical_unit(<<"f">>) -> tempF;
-binary_to_canonical_unit(<<"fahrenheit">>) -> tempF;
-% default
-binary_to_canonical_unit(_) -> unknown.
+-spec binary_to_canonical_unit(binary()) -> unit_or_unknown().
+binary_to_canonical_unit(<<"c">>) -> <<"celsius">>;
+binary_to_canonical_unit(<<"celsius">>) -> <<"celsius">>;
+binary_to_canonical_unit(<<"f">>) -> <<"fahrenheit">>;
+binary_to_canonical_unit(<<"fahrenheit">>) -> <<"fahrenheit">>;
+binary_to_canonical_unit(UnitBin) ->
+    validate_unit(re:run(UnitBin, <<"^[a-zA-Z]+$">>, [{capture, none}]), UnitBin).
 
--spec canonical_unit_to_binary(number(), unit()) -> binary().
-% weight
-canonical_unit_to_binary(1, mg) -> <<"milligram">>;
-canonical_unit_to_binary(_, mg) -> <<"milligrams">>;
-canonical_unit_to_binary(1, g) -> <<"gram">>;
-canonical_unit_to_binary(_, g) -> <<"grams">>;
-canonical_unit_to_binary(1, kg) -> <<"kilogram">>;
-canonical_unit_to_binary(_, kg) -> <<"kilograms">>;
-% volume
-canonical_unit_to_binary(_, ml) -> <<"ml">>;
-canonical_unit_to_binary(_, cc) -> <<"cc">>;
-canonical_unit_to_binary(1, floz) -> <<"fluid ounce">>;
-canonical_unit_to_binary(_, floz) -> <<"fluid ounces">>;
-% bandwidth
-% distance
-canonical_unit_to_binary(1, mm) -> <<"millimeter">>;
-canonical_unit_to_binary(_, mm) -> <<"millimeters">>;
-canonical_unit_to_binary(1, cm) -> <<"centimeter">>;
-canonical_unit_to_binary(_, cm) -> <<"centimeters">>;
-canonical_unit_to_binary(1, m) -> <<"meter">>;
-canonical_unit_to_binary(_, m) -> <<"meters">>;
-canonical_unit_to_binary(1, km) -> <<"kilometer">>;
-canonical_unit_to_binary(_, km) -> <<"kilometers">>;
-canonical_unit_to_binary(1, inch) -> <<"inch">>;
-canonical_unit_to_binary(_, inch) -> <<"inches">>;
-canonical_unit_to_binary(1, foot) -> <<"foot">>;
-canonical_unit_to_binary(_, foot) -> <<"feet">>;
-% temperature
-canonical_unit_to_binary(_, tempC) -> <<"celsius">>;
-canonical_unit_to_binary(_, tempF) -> <<"fahrenheit">>;
-% default
-canonical_unit_to_binary(1, Unit) -> atom_to_binary(Unit);
-canonical_unit_to_binary(_, Unit) ->
-    UnitBin = atom_to_binary(Unit),
-    <<UnitBin/binary, "s">>.
+-spec validate_unit(atom(), binary()) -> unit_or_unknown().
+validate_unit(match, Unit) when byte_size(Unit) < 30 -> Unit;
+validate_unit(nomatch, _Unit) -> unknown.

--- a/test/convert_SUITE.erl
+++ b/test/convert_SUITE.erl
@@ -42,26 +42,26 @@ end_per_testcase(_, _Config) ->
 unit_coverage(_) ->
     TestCases = [
         % weight
-        {<<"1">>, <<"g">>, <<"mg">>, <<"1 gram is equal to 1000 milligrams">>},
-        {<<"1">>, <<"kg">>, <<"g">>, <<"1 kilogram is equal to 1000 grams">>},
-        {<<"1">>, <<"pound">>, <<"ounce">>, <<"1 pound is equal to 16 ounces">>},
+        {<<"1">>, <<"g">>, <<"mg">>, <<"1 g = 1000 mg">>},
+        {<<"1">>, <<"kg">>, <<"g">>, <<"1 kg = 1000 g">>},
+        {<<"1">>, <<"pound">>, <<"ounce">>, <<"1 pound = 16 ounce">>},
         % volume
-        {<<"1">>, <<"liter">>, <<"ml">>, <<"1 liter is equal to 1000 ml">>},
-        {<<"1">>, <<"kiloliter">>, <<"cc">>, <<"1 kiloliter is equal to 1000000 cc">>},
-        {<<"1">>, <<"gallon">>, <<"qt">>, <<"1 gallon is equal to 4 quarts">>},
-        {<<"1">>, <<"gallon">>, <<"floz">>, <<"1 gallon is equal to 128 fluid ounces">>},
+        {<<"1">>, <<"liter">>, <<"ml">>, <<"1 liter = 1000 ml">>},
+        {<<"1">>, <<"kiloliter">>, <<"cc">>, <<"1 kiloliter = 1000000 cc">>},
+        {<<"1">>, <<"gallon">>, <<"qt">>, <<"1 gallon = 4 qt">>},
+        {<<"1">>, <<"gallon">>, <<"floz">>, <<"1 gallon = 128 floz">>},
         % bandwidth
-        {<<"1">>, <<"byte">>, <<"bit">>, <<"1 byte is equal to 8 bits">>},
-        {<<"1">>, <<"kb">>, <<"kilobit">>, <<"1 kilobyte is equal to 8 kilobits">>},
-        {<<"1">>, <<"mb">>, <<"megabit">>, <<"1 megabyte is equal to 8 megabits">>},
-        {<<"1">>, <<"gb">>, <<"gigabit">>, <<"1 gigabyte is equal to 8 gigabits">>},
-        {<<"1">>, <<"cm">>, <<"mm">>, <<"1 centimeter is equal to 10 millimeters">>},
-        {<<"1">>, <<"km">>, <<"m">>, <<"1 kilometer is equal to 1000 meters">>},
+        {<<"1">>, <<"byte">>, <<"bit">>, <<"1 byte = 8 bit">>},
+        {<<"1">>, <<"kilobyte">>, <<"kilobit">>, <<"1 kilobyte = 8 kilobit">>},
+        {<<"1">>, <<"megabyte">>, <<"megabit">>, <<"1 megabyte = 8 megabit">>},
+        {<<"1">>, <<"gigabyte">>, <<"gigabit">>, <<"1 gigabyte = 8 gigabit">>},
+        {<<"1">>, <<"cm">>, <<"mm">>, <<"1 cm = 10 mm">>},
+        {<<"1">>, <<"km">>, <<"m">>, <<"1 km = 1000 m">>},
         % distance
-        {<<"1">>, <<"mile">>, <<"yard">>, <<"1 mile is equal to 1760 yards">>},
-        {<<"1">>, <<"foot">>, <<"inch">>, <<"1 foot is equal to 12 inches">>},
+        {<<"1">>, <<"mile">>, <<"yard">>, <<"1 mile = 1760 yard">>},
+        {<<"1">>, <<"foot">>, <<"inch">>, <<"1 foot = 12 inch">>},
         % temperature
-        {<<"1">>, <<"celsius">>, <<"fahrenheit">>, <<"1 celsius is equal to 33.8 fahrenheit">>}
+        {<<"1">>, <<"celsius">>, <<"fahrenheit">>, <<"1 celsius = 33.8 fahrenheit">>}
     ],
     F = fun({UnitNum, UnitFrom, UnitTo, ExpectedShort}, Acc) ->
             Question = <<"convert ", UnitNum/binary, UnitFrom/binary, " to ", UnitTo/binary>>,

--- a/test/convert_web_SUITE.erl
+++ b/test/convert_web_SUITE.erl
@@ -75,7 +75,7 @@ convert_json(_) ->
     ExpectedResponse = [
         #{
             <<"question">> => <<"convert 20 km to miles">>,
-            <<"short">> => <<"20 kilometers is equal to 12.427424 miles">>,
+            <<"short">> => <<"20 km = 12.427424 miles">>,
             <<"type">> => <<"text">>
         }
     ],
@@ -93,7 +93,7 @@ convert_unrecognized_syntax(_) ->
     ok.
 
 convert_unsupported_unit(_) ->
-    Question = "convert 5 smoots to meters",
+    Question = "convert 5 jujumeters to meters",
     {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = request_json(Question),
     Response = decode_response_body(ResponseBody),
     true = lists:member({"content-type","application/json"}, Headers),


### PR DESCRIPTION
## Description

It's getting too cumbersome to add individual units that are allowed. One path forward would be to somehow export all supported units names from the `units` tool and auto-generate the list to validate input against. Another option is to take sanitized input and run units with it. If unit is unsupported (or there's a conformability error) we catch that and return error. This PR does the latter.

Unit names are expected to be `[a-zA-Z]` and less than 30 bytes.