### PR TITLE
Trim whitespace, make convert command case insensitive

### DIFF
--- a/src/rinseweb_manifests.erl
+++ b/src/rinseweb_manifests.erl
@@ -33,7 +33,7 @@ get_all() ->
             matches => [
                 #{
                     type => regex,
-                    value => <<"^convert ([-]?[0-9]*[.]?[0-9]+)\s*([a-zA-Z]+)\s+to\s+([a-zA-Z]+)$">>
+                    value => <<"^(?i:convert)\s+([-]?[0-9]*[.]?[0-9]+)\s*([a-zA-Z]+)\s+to\s+([a-zA-Z]+)$">>
                 }
             ],
             handler => rinseweb_wiz_convert

--- a/src/rinseweb_wiz.erl
+++ b/src/rinseweb_wiz.erl
@@ -28,8 +28,9 @@
 
 -spec answer(question()) -> answers().
 answer(Question) ->
-    {Handler, Args} = find_handler(Question, rinseweb_manifests:get_all()),
-    [Handler:answer(Question, Args)].
+    TrimmedQuestion = binary_trim(Question),
+    {Handler, Args} = find_handler(TrimmedQuestion, rinseweb_manifests:get_all()),
+    [Handler:answer(TrimmedQuestion, Args)].
 
 %%====================================================================
 %% Internal functions
@@ -61,3 +62,16 @@ find_handler_check_result({match, Handler, Args}, _Question, _Rest) ->
     {Handler, Args};
 find_handler_check_result(nomatch, Question, Rest) ->
     find_handler(Question, Rest).
+
+-spec binary_trim(binary()) -> binary().
+binary_trim(Bin) ->
+    binary_ltrim(binary_rtrim(Bin)).
+
+-spec binary_ltrim(binary()) -> binary().
+binary_ltrim(<<32, Bin/binary>>) -> binary_ltrim(Bin);
+binary_ltrim(Bin) -> Bin.
+
+-spec binary_rtrim(binary()) -> binary().
+binary_rtrim(Bin) when binary_part(Bin, {byte_size(Bin), -1}) =:= <<32>> ->
+    binary_rtrim(binary_part(Bin, {0, byte_size(Bin) - 1}));
+binary_rtrim(Bin) -> Bin.

--- a/test/convert_web_SUITE.erl
+++ b/test/convert_web_SUITE.erl
@@ -11,6 +11,8 @@
 
 %% Tests
 -export([convert_json/1]).
+-export([convert_json_extra_whitespace/1]).
+-export([convert_json_case_insensitive/1]).
 -export([convert_unrecognized_syntax/1]).
 -export([convert_unsupported_unit/1]).
 -export([convert_invalid_number/1]).
@@ -22,6 +24,8 @@
 all() ->
     [
         convert_json,
+        convert_json_extra_whitespace,
+        convert_json_case_insensitive,
         convert_unrecognized_syntax,
         convert_unsupported_unit,
         convert_invalid_number
@@ -75,6 +79,36 @@ convert_json(_) ->
     ExpectedResponse = [
         #{
             <<"question">> => <<"convert 20 km to miles">>,
+            <<"short">> => <<"20 km = 12.427424 miles">>,
+            <<"type">> => <<"text">>
+        }
+    ],
+    ExpectedResponse = Response,
+    ok.
+
+convert_json_extra_whitespace(_) ->
+    Question = "   convert 20 km to miles  ",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = request_json(Question),
+    Response = decode_response_body(ResponseBody),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ExpectedResponse = [
+        #{
+            <<"question">> => <<"convert 20 km to miles">>,
+            <<"short">> => <<"20 km = 12.427424 miles">>,
+            <<"type">> => <<"text">>
+        }
+    ],
+    ExpectedResponse = Response,
+    ok.
+
+convert_json_case_insensitive(_) ->
+    Question = "ConVerT 20 km to miles",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = request_json(Question),
+    Response = decode_response_body(ResponseBody),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ExpectedResponse = [
+        #{
+            <<"question">> => <<"ConVerT 20 km to miles">>,
             <<"short">> => <<"20 km = 12.427424 miles">>,
             <<"type">> => <<"text">>
         }


### PR DESCRIPTION
## Fixes

* Whitespace around the question is now trimmed
* Convert command match is now case insensitive
* Convert command allows any non-zero number of space characters after the command