### PR TITLE
Add hash wizard with sha, sha2 and md5 commands

### DIFF
--- a/src/rinseweb_manifests.erl
+++ b/src/rinseweb_manifests.erl
@@ -38,6 +38,15 @@ get_all() ->
             ],
             handler => rinseweb_wiz_convert
         },
+        #{ % hash
+            matches => [
+                #{
+                    type => regex,
+                    value => <<"^(sha|sha2|md5)\s+(.*)$">>
+                }
+            ],
+            handler => rinseweb_wiz_hash
+        },
         #{ % UUID
             matches => [
                 #{

--- a/src/rinseweb_wiz_hash.erl
+++ b/src/rinseweb_wiz_hash.erl
@@ -1,0 +1,43 @@
+%%%-------------------------------------------------------------------
+%% @doc rinseweb hash wizard
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(rinseweb_wiz_hash).
+
+%% API
+-export([answer/2]).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+-spec answer(rinseweb_wiz:question(), [any()]) -> rinseweb_wiz:answer().
+answer(Question, [<<"sha">>, Bin]) ->
+    #{
+        question => Question,
+        type => text,
+        short => format(crypto:hash(sha, Bin))
+    };
+answer(Question, [<<"sha2">>, Bin]) ->
+    #{
+        question => Question,
+        type => text,
+        short => format(crypto:hash(sha256, Bin))
+    };
+answer(Question, [<<"md5">>, Bin]) ->
+    #{
+        question => Question,
+        type => text,
+        short => format(crypto:hash(md5, Bin))
+    }.
+
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec format(binary()) -> binary().
+format(Bin) ->
+    Str = string:lowercase(lists:flatten([[io_lib:format("~2.16.0B",[X]) || <<X:8>> <= Bin ]])),
+    list_to_binary(Str).

--- a/test/hash_SUITE.erl
+++ b/test/hash_SUITE.erl
@@ -1,0 +1,75 @@
+-module(hash_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% ct functions
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+%% Tests
+-export([sha/1]).
+-export([sha2/1]).
+-export([md5/1]).
+
+%% ============================================================================
+%% ct functions
+%% ============================================================================
+
+all() ->
+    [
+        sha,
+        sha2,
+        md5
+    ].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_) ->
+    ok.
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+%% ============================================================================
+%% Tests
+%% ============================================================================
+
+sha(_) ->
+    Question = <<"sha hello">>,
+    ExpectedAnswer = #{
+        question => Question,
+        type => text,
+        short => <<"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d">>
+    },
+    Answer = rinseweb_wiz_hash:answer(Question, [<<"sha">>, <<"hello">>]),
+    ExpectedAnswer = Answer,
+    ok.
+
+sha2(_) ->
+    Question = <<"sha2 hello">>,
+    ExpectedAnswer = #{
+        question => Question,
+        type => text,
+        short => <<"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824">>
+    },
+    Answer = rinseweb_wiz_hash:answer(Question, [<<"sha2">>, <<"hello">>]),
+    ExpectedAnswer = Answer,
+    ok.
+
+md5(_) ->
+    Question = <<"md5 hello">>,
+    ExpectedAnswer = #{
+        question => Question,
+        type => text,
+        short => <<"5d41402abc4b2a76b9719d911017c592">>
+    },
+    Answer = rinseweb_wiz_hash:answer(Question, [<<"md5">>, <<"hello">>]),
+    ExpectedAnswer = Answer,
+    ok.

--- a/test/hash_web_SUITE.erl
+++ b/test/hash_web_SUITE.erl
@@ -1,0 +1,88 @@
+-module(hash_web_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% ct functions
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+%% Tests
+-export([sha/1]).
+-export([sha2/1]).
+-export([md5/1]).
+
+%% ============================================================================
+%% ct functions
+%% ============================================================================
+
+all() ->
+    [
+        sha,
+        sha2,
+        md5
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(rinseweb),
+    Config.
+
+end_per_suite(_) ->
+    ok = application:stop(rinseweb).
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+%% ============================================================================
+%% Tests
+%% ============================================================================
+
+sha(_) ->
+    Question = "sha hello",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
+    Response = rinseweb_test:decode_response_body(ResponseBody),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ExpectedResponse = [
+        #{
+            <<"question">> => <<"sha hello">>,
+            <<"short">> => <<"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d">>,
+            <<"type">> => <<"text">>
+        }
+    ],
+    ExpectedResponse = Response,
+    ok.
+
+sha2(_) ->
+    Question = "sha2 hello",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
+    Response = rinseweb_test:decode_response_body(ResponseBody),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ExpectedResponse = [
+        #{
+            <<"question">> => <<"sha2 hello">>,
+            <<"short">> => <<"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824">>,
+            <<"type">> => <<"text">>
+        }
+    ],
+    ExpectedResponse = Response,
+    ok.
+
+md5(_) ->
+    Question = "md5 hello",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
+    Response = rinseweb_test:decode_response_body(ResponseBody),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ExpectedResponse = [
+        #{
+            <<"question">> => <<"md5 hello">>,
+            <<"short">> => <<"5d41402abc4b2a76b9719d911017c592">>,
+            <<"type">> => <<"text">>
+        }
+    ],
+    ExpectedResponse = Response,
+    ok.

--- a/test/hash_web_SUITE.erl
+++ b/test/hash_web_SUITE.erl
@@ -13,6 +13,7 @@
 -export([sha/1]).
 -export([sha2/1]).
 -export([md5/1]).
+-export([separator_greedy_match/1]).
 
 %% ============================================================================
 %% ct functions
@@ -22,7 +23,8 @@ all() ->
     [
         sha,
         sha2,
-        md5
+        md5,
+        separator_greedy_match
     ].
 
 init_per_suite(Config) ->
@@ -80,6 +82,21 @@ md5(_) ->
     ExpectedResponse = [
         #{
             <<"question">> => <<"md5 hello">>,
+            <<"short">> => <<"5d41402abc4b2a76b9719d911017c592">>,
+            <<"type">> => <<"text">>
+        }
+    ],
+    ExpectedResponse = Response,
+    ok.
+
+separator_greedy_match(_) ->
+    Question = "md5         hello",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
+    Response = rinseweb_test:decode_response_body(ResponseBody),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ExpectedResponse = [
+        #{
+            <<"question">> => <<"md5         hello">>,
             <<"short">> => <<"5d41402abc4b2a76b9719d911017c592">>,
             <<"type">> => <<"text">>
         }


### PR DESCRIPTION
## Description

The following commands are now implemented with the hash wizard
* `sha foo` to get sha of string `foo`
* `sha2 bar` to get sha2 of string `bar`
* `md5 baz` to get md5 of string `baz`

Tests are included.