### PR TITLE
Static about and commands pages and minor fixes

### DIFF
--- a/priv/static/html/about.html
+++ b/priv/static/html/about.html
@@ -1,0 +1,70 @@
+<html>
+<head>
+    <meta charset="utf-8">
+	<title>rinse</title>
+    <style type="text/css">
+        h2 {font-size:5em;font-family:monospace;}
+        h2 a {text-decoration:none;}
+        #question {font-size:3em;font-family:sans-serif;}
+        #answer {font-size:3em;font-family:sans-serif;}
+        footer {position:fixed;bottom:0;text-align:center;width:100%;font-size:1em;font-family:sans-serif;}
+        p {margin-left:10%;font-family:sans-serif;margin-right:10%;}
+        h3 {font-size:1.5em;font-family:sans-serif;margin-left:10%;}
+        h4 {font-family:sans-serif;margin-left:10%;}
+        ul {margin-left:10%;font-family:sans-serif;}
+    </style>
+</head>
+<body>
+    <center>
+        <h2><a href="/"><span style="color:#0f2557">r</span><span style="color:#28559a">i</span><span style="color:#3778c2">n</span><span style="color:#4b9fe1">s</span><span style="color:#63bce5">e</span></a></h2>
+    </center>
+    <h3>What</h3>
+    <p>
+        <span style="font-family:monospace;font-size:1.5em;"><span style="color:#0f2557">r</span><span style="color:#28559a">i</span><span style="color:#3778c2">n</span><span style="color:#4b9fe1">s</span><span style="color:#63bce5">e</span></span>
+        is not a search engine. It is a collection of specific <a href="/commands">commands</a> meant to return instantly
+        useful answers.
+    </p>
+    <p>
+        <span style="font-family:monospace;font-size:1.5em;"><span style="color:#0f2557">r</span><span style="color:#28559a">i</span><span style="color:#3778c2">n</span><span style="color:#4b9fe1">s</span><span style="color:#63bce5">e</span></span>
+        is a fully open source project that anyone can contribute to.
+    </p>
+    <h3>Why</h3>
+    <p>
+        There are 2 main reasons:
+        <ul>
+            <li>Make it useful so we can get instant relevant answers to common queries</li>
+            <li>Give an example of how to fully deploy and manage a web application</li>
+        </ul>
+    </p>
+    <h3>How</h3>
+    <p>
+        <h4>Technical details:</h4>
+        <ul>
+            <li>Written in <a href="https://www.erlang.org/">Erlang/OTP</a> using <a href="https://github.com/ninenines/cowboy">Cowboy</a> web server</li>
+            <li>Hosted in AWS (Amazon Web Services)</li>
+            <li>Deployed using Ansible and CloudFormation</li>
+        </ul>
+        <h4>Source code:</h4>
+        <ul>
+            <li>Organization on GitHub: <a href="https://github.com/RinseOne">RinseOne</a></li>
+            <li>Source code for rinse.one web application: <a href="https://github.com/RinseOne/rinseweb">rinseweb</a></li>
+            <li>Source code for infrastructure and deployment: <a href="https://github.com/RinseOne/ansible-playbooks">playbooks</a></li>
+        </ul>
+    </p>
+    <h3>Contribute</h3>
+    <p>
+        Contributions are highly encouraged.
+    </p>
+    <p>
+        The entire stack - front/back end code, infrastructure setup and deployment are all published openly.
+        If you can think of ways to improve any of it, feel free to file an issue, or send a PR.
+    </p>
+    <p>
+        If you are not a software engineer, don't despair. Ideas on what to add next or how to make current
+        commands better are welcome too.
+    </p>
+<footer>
+    <p><a href="/about">About</a> - <a href="/commands">Commands</a></p>
+</footer>
+</body>
+</html>

--- a/priv/static/html/commands.html
+++ b/priv/static/html/commands.html
@@ -1,0 +1,57 @@
+<html>
+<head>
+    <meta charset="utf-8">
+	<title>rinse</title>
+    <style type="text/css">
+        h2 {font-size:5em;font-family:monospace;}
+        h2 a {text-decoration:none;}
+        #question {font-size:3em;font-family:sans-serif;}
+        #answer {font-size:3em;font-family:sans-serif;}
+        footer {position:fixed;bottom:0;text-align:center;width:100%;font-size:1em;font-family:sans-serif;}
+        p {margin-left:10%;font-family:sans-serif;margin-right:10%;}
+        h3 {font-size:1.5em;font-family:sans-serif;margin-left:10%;}
+        h4 {font-family:sans-serif;margin-left:10%;}
+        ul {margin-left:10%;font-family:sans-serif;}
+    </style>
+</head>
+<body>
+    <center>
+        <h2><a href="/"><span style="color:#0f2557">r</span><span style="color:#28559a">i</span><span style="color:#3778c2">n</span><span style="color:#4b9fe1">s</span><span style="color:#63bce5">e</span></a></h2>
+    </center>
+    <h3>Commands</h3>
+    <p>
+        <span style="font-family:monospace;font-size:1.5em;"><span style="color:#0f2557">r</span><span style="color:#28559a">i</span><span style="color:#3778c2">n</span><span style="color:#4b9fe1">s</span><span style="color:#63bce5">e</span></span>
+        currently supports the following commands:
+        <ul>
+            <li>
+                <code>convert</code>: convert between arbitrary units. Examples:<br/>
+                <code>convert 14kg to pounds</code><br/>
+                <code>convert 16 weeks to months</code><br/>
+                <code>convert 15 meters to smoots</code><br/>
+            </li>
+            <li>
+                <code>md5</code>: compute MD5 hash of the string that follows. Example:
+                <code>md5 hello there</code>
+            </li>
+            <li>
+                <code>sha</code>: compute SHA1 hash of the string that follows. Example:
+                <code>sha hello there</code>
+            </li>
+            <li>
+                <code>sha2</code>: compute SHA256 hash of the string that follows. Example:
+                <code>sha2 hello there</code>
+            </li>
+            <li>
+                <code>uuid</code>: generate a new UUID with every request
+            </li>
+        </ul>
+    </p>
+    <h3>Contribute</h3>
+    <p>
+        Help make it better by contributing - see details on the <a href="/about">about</a> page.
+    </p>
+<footer>
+    <p><a href="/about">About</a> - <a href="/commands">Commands</a></p>
+</footer>
+</body>
+</html>

--- a/src/rinseweb_app.erl
+++ b/src/rinseweb_app.erl
@@ -14,6 +14,8 @@ start(_StartType, _StartArgs) ->
         {'_', [
             {"/", rinseweb_h_root, []},
             {"/answer/[:question]", rinseweb_h_answer, []},
+            {"/about", cowboy_static, {priv_file, rinseweb, "static/html/about.html"}},
+            {"/commands", cowboy_static, {priv_file, rinseweb, "static/html/commands.html"}},
             {"/assets/[...]", cowboy_static, {priv_dir, rinseweb, "static/assets"}}
         ]}
     ]),

--- a/src/rinseweb_h_answer.erl
+++ b/src/rinseweb_h_answer.erl
@@ -35,13 +35,23 @@ answer_to_html(Req, State) ->
     Body = <<"<html>
 <head>
     <meta charset=\"utf-8\">
-    <title>rinse answer</title>
+	<title>rinse</title>
+    <style type=\"text/css\">
+        h2 {font-size:5em;font-family:monospace;}
+        #question {font-size:3em;font-family:sans-serif;}
+        #answer {font-size:3em;font-family:sans-serif;}
+        footer {position:fixed;bottom:0;text-align:center;width:100%;font-size:1em;font-family:sans-serif;}
+    </style>
 </head>
 <body>
     <center>
-        <p>", QuestionSafe/binary, "</p>
-        <p>", AnswerSafe/binary, "</p>
+        <h2><span style=\"color:#0f2557\">r</span><span style=\"color:#28559a\">i</span><span style=\"color:#3778c2\">n</span><span style=\"color:#4b9fe1\">s</span><span style=\"color:#63bce5\">e</span></h2>
+        <p id=\"question\">", QuestionSafe/binary, "</p>
+        <p id=\"answer\">", AnswerSafe/binary, "</p>
     </center>
+<footer>
+    <p><a href=\"/about\">About</a> - <a href=\"/commands\">Commands</a></p>
+</footer>
 </body>
 </html>">>,
     {Body, Req, State}.

--- a/src/rinseweb_h_root.erl
+++ b/src/rinseweb_h_root.erl
@@ -37,28 +37,33 @@ hello_to_html(Req, State) ->
 	<title>rinse</title>
     <script type=\"text/javascript\" src=\"/assets/app.js\" nonce=\"",Nonce/binary,"\"></script>
     <style type=\"text/css\">
-        h2 {font-size:5em;font-family: monospace;}
+        h2 {font-size:5em;font-family:monospace;}
         input[type=\"text\"] {font-size:3em;}
-        #answer {font-size:2em;}
+        #answer {font-size:3em;font-family:sans-serif;}
+        footer {position:fixed;bottom:0;text-align:center;width:100%;font-size:1em;font-family:sans-serif;}
     </style>
 </head>
 <body>
     <center>
         <h2><span style=\"color:#0f2557\">r</span><span style=\"color:#28559a\">i</span><span style=\"color:#3778c2\">n</span><span style=\"color:#4b9fe1\">s</span><span style=\"color:#63bce5\">e</span></h2>
         <form id=\"search\">
-            <input id=\"question\" type=\"text\" size=\"30\" style=\"text-align:center\" />
+            <input id=\"question\" type=\"text\" autocapitalize=\"none\" size=\"30\" style=\"text-align:center\" />
         </form>
-        <br/>
+        <br/><br/>
         <div id=\"answer\">
         </div>
     </center>
+<footer>
+    <p><a href=\"/about\">About</a> - <a href=\"/commands\">Commands</a></p>
+</footer>
 </body>
 </html>">>,
     {Body, Req, State}.
 
 hello_to_json(Req, State) ->
-    Body = <<"{\"rest\": \"Hello World!\"}">>,
+    Body = <<"{\"rinse\": \"rinse is not a search engine.\"}">>,
     {Body, Req, State}.
 
 hello_to_text(Req, State) ->
-    {<<"REST Hello World as text!">>, Req, State}.
+    Body = <<"rinse\nrinse is not a search engine.">>,
+    {Body, Req, State}.

--- a/src/rinseweb_wiz_uuid.erl
+++ b/src/rinseweb_wiz_uuid.erl
@@ -13,9 +13,9 @@
 %%====================================================================
 
 -spec answer(rinseweb_wiz:question(), [any()]) -> rinseweb_wiz:answer().
-answer(<<"uuid">>, []) ->
+answer(Question, []) ->
     #{
-        question => <<"uuid">>,
+        question => Question,
         type => text,
         short => list_to_binary(uuid:uuid_to_string(uuid:get_v4()))
     }.

--- a/test/base_SUITE.erl
+++ b/test/base_SUITE.erl
@@ -12,6 +12,8 @@
 %% Tests
 -export([web_root_response_contains_form/1]).
 -export([web_app_js_loads/1]).
+-export([web_about_page_loads/1]).
+-export([web_commands_page_loads/1]).
 
 %% ============================================================================
 %% ct functions
@@ -20,7 +22,9 @@
 all() ->
     [
         web_root_response_contains_form,
-        web_app_js_loads
+        web_app_js_loads,
+        web_about_page_loads,
+        web_commands_page_loads
     ].
 
 init_per_suite(Config) ->
@@ -48,4 +52,12 @@ web_root_response_contains_form(_) ->
 
 web_app_js_loads(_) ->
     {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request("http://localhost:8080/assets/app.js"),
+    ok.
+
+web_about_page_loads(_) ->
+    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request("http://localhost:8080/about"),
+    ok.
+
+web_commands_page_loads(_) ->
+    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request("http://localhost:8080/commands"),
     ok.


### PR DESCRIPTION
## Description

* Adds new `/about` and `/commands` pages to provide basic info, links to project and document available commands
* Links from other pages to about and commands pages
* Turns off `autocapitalize` setting for the main input text box
* Makes the `uuid` command not return 500 when not all lowercase