### PR TITLE
Add commands for simple timestamps

### DIFF
--- a/src/rinseweb_manifests.erl
+++ b/src/rinseweb_manifests.erl
@@ -38,6 +38,19 @@ get_all() ->
             ],
             handler => rinseweb_wiz_convert
         },
+        #{ % unix timestamp
+            matches => [
+                #{
+                    type => regex,
+                    value => <<"^([\\d]{10}|[\\d]{13})$">>
+                },
+                #{
+                    type => regex,
+                    value => <<"^(?i:unix timestamp|now|timestamp)$">>
+                }
+            ],
+            handler => rinseweb_wiz_timestamp
+        },
         #{ % hash
             matches => [
                 #{

--- a/src/rinseweb_wiz_timestamp.erl
+++ b/src/rinseweb_wiz_timestamp.erl
@@ -1,0 +1,63 @@
+%%%-------------------------------------------------------------------
+%% @doc rinseweb unix timestamp wizard
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(rinseweb_wiz_timestamp).
+
+%% API
+-export([answer/2]).
+
+%% Types
+-type time_unit() :: second | millisecond.
+
+%%====================================================================
+%% API
+%%====================================================================
+
+-spec answer(rinseweb_wiz:question(), [any()]) -> rinseweb_wiz:answer().
+answer(Question, []) ->
+    Timestamp = erlang:system_time(second),
+    #{
+        question => Question,
+        type => text,
+        short => integer_to_binary(Timestamp)
+    };
+answer(Question, [Bin]) ->
+    Type = timestamp_unit(Bin),
+    Num = binary_to_integer(Bin),
+    DateTime = calendar:system_time_to_universal_time(Num, Type),
+    #{
+        question => Question,
+        type => text,
+        short => format(DateTime)
+    }.
+
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec timestamp_unit(binary()) -> time_unit().
+timestamp_unit(Bin) when byte_size(Bin) =:= 10 -> second;
+timestamp_unit(Bin) when byte_size(Bin) =:= 13 -> millisecond.
+
+-spec format(calendar:datetime()) -> binary().
+format({{Year, Month, Day}, {Hour, Minute, Second}}) ->
+    YearBin = integer_to_binary(Year),
+    MonthBin = pad_date_digits(integer_to_binary(Month)),
+    DayBin = pad_date_digits(integer_to_binary(Day)),
+    HourBin = pad_date_digits(integer_to_binary(Hour)),
+    MinuteBin = pad_date_digits(integer_to_binary(Minute)),
+    SecondBin = pad_date_digits(integer_to_binary(Second)),
+    <<YearBin/binary, "-", MonthBin/binary, "-", DayBin/binary, " ", HourBin/binary, ":", MinuteBin/binary, ":", SecondBin/binary, " UTC">>.
+
+-spec pad_date_digits(binary()) -> binary().
+pad_date_digits(Bin) ->
+    pad_binary(2, <<"0">>, Bin).
+
+-spec pad_binary(integer(), binary(), binary()) -> binary().
+pad_binary(Length, _Byte, Bin) when byte_size(Bin) >= Length ->
+    Bin;
+pad_binary(Length, Byte, Bin) when byte_size(Bin) < Length ->
+    pad_binary(Length, Byte, <<Byte/binary, Bin/binary>>).

--- a/test/timestamp_SUITE.erl
+++ b/test/timestamp_SUITE.erl
@@ -1,0 +1,62 @@
+-module(timestamp_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% ct functions
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+%% Tests
+-export([seconds/1]).
+-export([milliseconds/1]).
+
+%% ============================================================================
+%% ct functions
+%% ============================================================================
+
+all() ->
+    [
+        seconds,
+        milliseconds
+    ].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_) ->
+    ok.
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+%% ============================================================================
+%% Tests
+%% ============================================================================
+
+seconds(_) ->
+    Question = <<"1624433430">>,
+    ExpectedAnswer = #{
+        question => Question,
+        type => text,
+        short => <<"2021-06-23 07:30:30 UTC">>
+    },
+    Answer = rinseweb_wiz_timestamp:answer(Question, [<<"1624433430">>]),
+    ExpectedAnswer = Answer,
+    ok.
+
+milliseconds(_) ->
+    Question = <<"1624433430000">>,
+    ExpectedAnswer = #{
+        question => Question,
+        type => text,
+        short => <<"2021-06-23 07:30:30 UTC">>
+    },
+    Answer = rinseweb_wiz_timestamp:answer(Question, [<<"1624433430">>]),
+    ExpectedAnswer = Answer,
+    ok.

--- a/test/timestamp_SUITE.erl
+++ b/test/timestamp_SUITE.erl
@@ -12,6 +12,7 @@
 %% Tests
 -export([seconds/1]).
 -export([milliseconds/1]).
+-export([timestamp/1]).
 
 %% ============================================================================
 %% ct functions
@@ -20,7 +21,8 @@
 all() ->
     [
         seconds,
-        milliseconds
+        milliseconds,
+        timestamp
     ].
 
 init_per_suite(Config) ->
@@ -60,3 +62,21 @@ milliseconds(_) ->
     Answer = rinseweb_wiz_timestamp:answer(Question, [<<"1624433430">>]),
     ExpectedAnswer = Answer,
     ok.
+
+timestamp(_) ->
+    TestStartTime = erlang:system_time(second),
+    Questions = [<<"now">>, <<"timestamp">>, <<"unix timestamp">>],
+    F = fun (Question, Acc) ->
+            Answer = rinseweb_wiz_timestamp:answer(Question, []),
+            AnswerQuestion = maps:get(question, Answer),
+            Question = AnswerQuestion,
+            AnswerType = maps:get(type, Answer),
+            text = AnswerType,
+            AnswerTimeBin = maps:get(short, Answer),
+            AnswerTimeInt = binary_to_integer(AnswerTimeBin),
+            OneMinFromTestStart = TestStartTime + 60,
+            true = AnswerTimeInt >= TestStartTime,
+            true = AnswerTimeInt < OneMinFromTestStart,
+            Acc
+        end,
+    ok = lists:foldr(F, ok, Questions).

--- a/test/timestamp_web_SUITE.erl
+++ b/test/timestamp_web_SUITE.erl
@@ -1,0 +1,71 @@
+-module(timestamp_web_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% ct functions
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+%% Tests
+-export([seconds/1]).
+-export([milliseconds/1]).
+
+%% ============================================================================
+%% ct functions
+%% ============================================================================
+
+all() ->
+    [
+        seconds,
+        milliseconds
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(rinseweb),
+    Config.
+
+end_per_suite(_) ->
+    ok = application:stop(rinseweb).
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+%% ============================================================================
+%% Tests
+%% ============================================================================
+
+seconds(_) ->
+    Question = "1624433430",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
+    Response = rinseweb_test:decode_response_body(ResponseBody),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ExpectedResponse = [
+        #{
+            <<"question">> => <<"1624433430">>,
+            <<"short">> => <<"2021-06-23 07:30:30 UTC">>,
+            <<"type">> => <<"text">>
+        }
+    ],
+    ExpectedResponse = Response,
+    ok.
+
+milliseconds(_) ->
+    Question = "1624433430000",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
+    Response = rinseweb_test:decode_response_body(ResponseBody),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ExpectedResponse = [
+        #{
+            <<"question">> => <<"1624433430000">>,
+            <<"short">> => <<"2021-06-23 07:30:30 UTC">>,
+            <<"type">> => <<"text">>
+        }
+    ],
+    ExpectedResponse = Response,
+    ok.


### PR DESCRIPTION
## Description

Adds following commands
* any 10 digit number will be converted from unix timestamp to UTC date and time
* any 13 digit number will be converted from unix milliseconds to UTC date and time
* `now`, `timestamp` and `unix timestamp` commands will return current unix timestamp