### PR TITLE
Allow convert area and volume exponent syntax

### DIFF
--- a/priv/static/html/commands.html
+++ b/priv/static/html/commands.html
@@ -33,7 +33,7 @@
                 <code>convert</code>: convert between arbitrary units. Examples:<br/>
                 <code>convert 14kg to pounds</code><br/>
                 <code>convert 16 weeks to months</code><br/>
-                <code>convert 15 meters to smoots</code><br/>
+                <code>convert 15 meter^2 to smoot^2</code><br/>
             </li>
             <li>
                 <code>md5</code>: compute MD5 hash of the string that follows. Example:

--- a/src/rinseweb_manifests.erl
+++ b/src/rinseweb_manifests.erl
@@ -33,7 +33,7 @@ get_all() ->
             matches => [
                 #{
                     type => regex,
-                    value => <<"^(?i:convert)\s+([-]?[0-9]*[.]?[0-9]+)\s*([a-zA-Z]+)\s+to\s+([a-zA-Z]+)$">>
+                    value => <<"^(?i:convert)\\s+([-]?[0-9]*[.]?[0-9]+)\\s*([a-zA-Z]+[\\^]?[2-3]?)\\s+to\\s+([a-zA-Z]+[\\^]?[2-3]?)$">>
                 }
             ],
             handler => rinseweb_wiz_convert

--- a/src/rinseweb_wiz_convert.erl
+++ b/src/rinseweb_wiz_convert.erl
@@ -92,6 +92,7 @@ binary_to_number(B) ->
 string_to_number([]) -> undefined;
 string_to_number("conformability error") -> undefined;
 string_to_number([$U,$n,$k,$n,$o,$w,$n|_]) -> undefined; % Handles "Unknown unit 'foo'" error
+string_to_number([$E,$r,$r,$o,$r|_]) -> undefined; % Handles "Error in 'foo': Parse error" error
 string_to_number(S) ->
     case string:to_float(S) of
         {error, no_float} -> list_to_integer(S);
@@ -108,7 +109,7 @@ binary_to_canonical_unit(<<"celsius">>) -> <<"celsius">>;
 binary_to_canonical_unit(<<"f">>) -> <<"fahrenheit">>;
 binary_to_canonical_unit(<<"fahrenheit">>) -> <<"fahrenheit">>;
 binary_to_canonical_unit(UnitBin) ->
-    validate_unit(re:run(UnitBin, <<"^[a-zA-Z]+$">>, [{capture, none}]), UnitBin).
+    validate_unit(re:run(UnitBin, <<"^[a-zA-Z]+[\\^]?[2-3]?$">>, [{capture, none}]), UnitBin).
 
 -spec validate_unit(atom(), binary()) -> unit_or_unknown().
 validate_unit(match, Unit) when byte_size(Unit) < 30 -> Unit;

--- a/test/convert_SUITE.erl
+++ b/test/convert_SUITE.erl
@@ -60,6 +60,10 @@ unit_coverage(_) ->
         % distance
         {<<"1">>, <<"mile">>, <<"yard">>, <<"1 mile = 1760 yard">>},
         {<<"1">>, <<"foot">>, <<"inch">>, <<"1 foot = 12 inch">>},
+        % area
+        {<<"1">>, <<"meter^2">>, <<"foot^2">>, <<"1 meter^2 = 10.76391 foot^2">>},
+        % volume
+        {<<"1">>, <<"meter^3">>, <<"foot^3">>, <<"1 meter^3 = 35.314667 foot^3">>},
         % temperature
         {<<"1">>, <<"celsius">>, <<"fahrenheit">>, <<"1 celsius = 33.8 fahrenheit">>}
     ],
@@ -80,7 +84,8 @@ unit_invalid(_) ->
         {<<"kg">>, <<"foo">>},
         {<<"foo">>, <<"kg">>},
         {<<"foo">>, <<"bar">>},
-        {<<"kg">>, <<"mm">>}
+        {<<"kg">>, <<"mm">>},
+        {<<"meters^2">>, <<"^2">>}
     ],
     UnitNum = <<"1">>,
     F = fun({UnitFrom, UnitTo}, Acc) ->


### PR DESCRIPTION
## Description

Tweak convert regex syntax to allow `^2` and `^3` unit modifiers for area and volume.