### PR TITLE
Add set-version Makefile target for convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,8 @@ doc:
 tests:
 	@$(REBAR3) ct --logdir logs/ct
 
-.PHONY: all compile dialyze deps rel run doc tests
+set-version:
+	@sed -i "s/{rinseweb, \"[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\"}/{rinseweb, \"$(version)\"}/" rebar.config
+	@sed -i "s/{vsn, \"[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\"}/{vsn, \"$(version)\"}/" src/rinseweb.app.src
+
+.PHONY: all compile dialyze deps rel run doc tests set-version

--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ Run tests
 ```
 make tests
 ```
+
+## Convenience
+
+Update version to prepare for release; for example, to set version `1.2.3`:
+```
+make set-version version=1.2.3
+```


### PR DESCRIPTION
## Description

The new `set-version` is a phony target for convenience of increasing the version number prior to creating a release. Sample usage
```
make set-version version=1.2.3
```
It updates the `rebar.config` and `src/rinseweb.app.src` files with the specified version.