### PR TITLE
Add Wikipedia search (English)

### DIFF
--- a/priv/static/assets/app.js
+++ b/priv/static/assets/app.js
@@ -24,31 +24,48 @@ function render_answer(json) {
     answerElem = document.getElementById('answer');
     removeAllChildren(answerElem);
     if (json.answers.length == 0) {
-        answerTextNode = document.createTextNode("¯\\_(ツ)_/¯")
+        answerNode = document.createTextNode("¯\\_(ツ)_/¯")
     } else {
-        answerText = answerToText(json.answers[0]);
-        answerTextNode = document.createTextNode(answerText);
+        answerNode = answerToNode(json.answers[0]);
     }
-    answerElem.appendChild(answerTextNode);
+    answerElem.appendChild(answerNode);
 }
 
-function answerToText(answer) {
-    txt = ""
+function answerToNode(answer) {
+    var node;
     switch(answer.type) {
         case "text":
-            txt = answer.answer.text;
+            node = document.createTextNode(answer.answer.text);
             break;
         case "hash":
-            txt = answer.answer.hash;
+            node = document.createTextNode(answer.answer.hash);
             break;
         case "conversion_result":
-            a = answer.answer;
-            txt = a.unit_from_number + " " + a.unit_from_name + " = " + a.unit_to_number + " " + a.unit_to_name
+            const a = answer.answer;
+            var txt = a.unit_from_number + " " + a.unit_from_name + " = " + a.unit_to_number + " " + a.unit_to_name
+            node = document.createTextNode(txt);
+            break;
+        case "wiki":
+            node = document.createElement('ul');
+            results = answer.answer;
+            for (let i = 0; i < results.length; i++) {
+                var itemNode = document.createElement('li');
+                var linkNode = document.createElement('a');
+                var linkAttr = document.createAttribute('href');
+                linkAttr.value = results[i].url;
+                linkNode.setAttributeNode(linkAttr);
+                linkNode.appendChild(document.createTextNode(results[i].title));
+                var descNode = document.createElement('span');
+                descNode.innerHTML = results[i].snippet;
+                itemNode.appendChild(linkNode);
+                itemNode.appendChild(descNode);
+                node.appendChild(itemNode);
+            }
             break;
         default:
-            txt = "";
+            node = document.createTextNode("");
     };
-    return txt;
+    return node;
 }
 
 function removeAllChildren(node) {

--- a/src/rinseweb_h_root.erl
+++ b/src/rinseweb_h_root.erl
@@ -39,7 +39,10 @@ hello_to_html(Req, State) ->
     <style type=\"text/css\">
         h2 {font-size:5em;font-family:monospace;}
         input[type=\"text\"] {font-size:3em;}
-        #answer {font-size:3em;font-family:sans-serif;}
+        div#answer {font-size:3em;font-family:sans-serif;}
+        div#answer > ul {margin:0;padding:0;list-style-type:none;font-size:0.5em;width:80%;}
+        div#answer > ul > li {white-space:nowrap;overflow:hidden;text-overflow:clip;margin:10px;}
+        div#answer > ul > li > span {margin-left:20px}
         footer {position:fixed;bottom:0;text-align:center;width:100%;font-size:1em;font-family:sans-serif;}
     </style>
 </head>

--- a/src/rinseweb_manifests.erl
+++ b/src/rinseweb_manifests.erl
@@ -44,6 +44,20 @@ get_all() ->
             },
             handler => rinseweb_wiz_convert
         },
+        #{ % wikipedia
+            matches => [
+                #{
+                    type => regex,
+                    value => <<"^(?i:wiki)\s+(.*)$">>
+                }
+            ],
+            cache => #{
+                n => 10,           % 10 segments
+                ttl => 86400,      % 1 day
+                memory => 10485760 % 10 MB
+            },
+            handler => rinseweb_wiz_wiki
+        },
         #{ % unix timestamp
             matches => [
                 #{

--- a/src/rinseweb_wiz.erl
+++ b/src/rinseweb_wiz.erl
@@ -23,9 +23,9 @@
     source := answer_source(),
     answer => answer_custom()
 }.
--type answer_type() :: shrug | text | conversion_result | hash.
+-type answer_type() :: shrug | text | conversion_result | hash | wiki.
 -type answer_source() :: atom().
--type answer_custom() :: map().
+-type answer_custom() :: any().
 -type args() :: [any()].
 
 -export_type([question/0]).

--- a/src/rinseweb_wiz_wiki.erl
+++ b/src/rinseweb_wiz_wiki.erl
@@ -1,0 +1,60 @@
+%%%-------------------------------------------------------------------
+%% @doc rinseweb wiki wizard
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(rinseweb_wiz_wiki).
+
+%% API
+-export([answer/2]).
+
+%% Types
+-type item() :: #{
+    title := binary(),
+    snippet := binary(),
+    url := binary()
+}.
+
+-define(URL, "https://en.wikipedia.org/w/api.php?action=query&format=json&generator=search&gsrprop=snippet&prop=info&inprop=url&gsrsearch=").
+
+%%====================================================================
+%% API
+%%====================================================================
+
+-spec answer(rinseweb_wiz:question(), [any()]) -> rinseweb_wiz:answer().
+answer(_Question, [Query]) ->
+    search(binary_to_list(Query)).
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec url_encode(string()) -> string().
+url_encode(Str) ->
+    edoc_lib:escape_uri(Str).
+
+-spec search(string()) -> rinseweb_wiz:answer().
+search(Query) ->
+    QueryEncoded = url_encode(Query),
+    Url = ?URL ++ QueryEncoded,
+    Req = {Url, []},
+    Response = httpc:request(get, Req, [], [{body_format, binary}]),
+    parse_response(Response).
+
+-spec parse_response({ok, {httpc:status_line(), httpc:headers(), binary()}} | {error, term()}) -> rinseweb_wiz:answer().
+parse_response({error, _Reason}) -> rinseweb_wiz:shrug(wiki);
+parse_response({ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}}) ->
+    BodyDecoded = jsx:decode(Body, [{return_maps, true}]),
+    rinseweb_wiz:answer(wiki, wiki, parse_body(BodyDecoded));
+parse_response({ok, {{_Version, _Status, _ReasonPhrase}, _Headers, _Body}}) ->
+    rinseweb_wiz:shrug(wiki).
+
+-spec parse_body(map()) -> [item()].
+parse_body(#{<<"query">> := #{<<"pages">> := PagesMap}}) ->
+    Pages = maps:values(PagesMap),
+    F = fun(#{<<"title">> := Title, <<"snippet">> := Snippet, <<"fullurl">> := Url}, Acc) ->
+            Elem = #{title => Title, snippet => Snippet, url => Url},
+            [Elem|Acc]
+        end,
+    lists:foldl(F, [], Pages);
+parse_body(_BodyDecoded) -> [].

--- a/test/wiki_SUITE.erl
+++ b/test/wiki_SUITE.erl
@@ -1,0 +1,51 @@
+-module(wiki_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% ct functions
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+%% Tests
+-export([search/1]).
+
+%% ============================================================================
+%% ct functions
+%% ============================================================================
+
+all() ->
+    [
+        search
+    ].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_) ->
+    ok.
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+%% ============================================================================
+%% Tests
+%% ============================================================================
+
+search(_) ->
+    Question = <<"wiki hello">>,
+    Answer = rinseweb_wiz_wiki:answer(Question, [<<"hello">>]),
+    wiki = maps:get(type, Answer),
+    wiki = maps:get(source, Answer),
+    AnswerCustom = maps:get(answer, Answer),
+    true = is_list(AnswerCustom),
+    true = length(AnswerCustom) > 0,
+    [FirstItem|_] = AnswerCustom,
+    true = maps:is_key(title, FirstItem),
+    true = maps:is_key(snippet, FirstItem),
+    true = maps:is_key(url, FirstItem).

--- a/test/wiki_web_SUITE.erl
+++ b/test/wiki_web_SUITE.erl
@@ -1,0 +1,57 @@
+-module(wiki_web_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% ct functions
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+%% Tests
+-export([search/1]).
+
+%% ============================================================================
+%% ct functions
+%% ============================================================================
+
+all() ->
+    [
+        search
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(rinseweb),
+    Config.
+
+end_per_suite(_) ->
+    ok = application:stop(rinseweb).
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+%% ============================================================================
+%% Tests
+%% ============================================================================
+
+search(_) ->
+    Question = "wiki hello",
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
+    ExpectedQuestion = list_to_binary(Question),
+    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
+    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    <<"wiki">> = maps:get(<<"type">>, Answer),
+    AnswerCustom = maps:get(<<"answer">>, Answer),
+    true = is_list(AnswerCustom),
+    true = length(AnswerCustom) > 0,
+    [FirstItem|_] = AnswerCustom,
+    true = maps:is_key(<<"title">>, FirstItem),
+    true = maps:is_key(<<"snippet">>, FirstItem),
+    true = maps:is_key(<<"url">>, FirstItem),
+    ok.


### PR DESCRIPTION
## Description

Adds English Wikipedia search using the [query action API](https://en.wikipedia.org/w/api.php?action=help&modules=query). It performs full text search using these options
* `action=query`: it is a query action
* `format=json`
* `generator=search`: this worked better than `list=search` (for which there was no way to add URLs in search results)
* `gsrprop=snippet`: also include snippets in results
* `prop=info`: needed to include URLs below
* `inprop=url`: yes, please include URLs
* `gsrsearch=`: the query string

Responses are also cached in memory for up to 1 day, 10 MB total size.