### PR TITLE
Add wiki command to the commands page

### DIFF
--- a/priv/static/html/commands.html
+++ b/priv/static/html/commands.html
@@ -53,6 +53,10 @@
             <li>
                 <code>uuid</code>: generate a new UUID with every request
             </li>
+            <li>
+                <code>wiki</code>: full text search for English Wikipedia. Examples:<br/>
+                <code>wiki erlang programming</code><br/>
+            </li>
         </ul>
     </p>
     <h3>Contribute</h3>


### PR DESCRIPTION
## Description

The `commands.html` update was missed during the initial `wiki` command PR.