### PR TITLE
Update Erlang/OTP to 24.0.5 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Set up Erlang
         uses: gleam-lang/setup-erlang@v1.1.2
         with:
-          # https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_24.0.1-1~ubuntu~focal_amd64.deb
-          otp-version: 24.0.1
+          # https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_24.0.5-1~ubuntu~focal_amd64.deb
+          otp-version: 24.0.5
       - name: Install units
         run: sudo apt install units
       - name: Test


### PR DESCRIPTION
## Description

Updates release Erlang/OTP version from 24.0.1 to 24.0.5. This is used for building the release.