### PR TITLE
Add DuckDuckGo images, video, news and maps search redirects

### DIFF
--- a/priv/static/assets/app.js
+++ b/priv/static/assets/app.js
@@ -119,10 +119,11 @@ function answerToNode(answer) {
             node = document.createElement('div');
             node.setAttribute('class', 'simple')
             var url = answer.answer.url;
+            var source = answer.answer.source;
             var query  = answer.answer.query;
             var linkNode = document.createElement('a');
             linkNode.setAttribute('href', url);
-            linkNode.appendChild(document.createTextNode('Search DuckDuckGo for ' + query))
+            linkNode.appendChild(document.createTextNode('Search ' + source + ' for ' + query));
             node.appendChild(linkNode);
             window.open(url, '_blank');
             break;

--- a/priv/static/html/commands.html
+++ b/priv/static/html/commands.html
@@ -40,6 +40,22 @@
                 <code>ddg online privacy</code><br/>
             </li>
             <li>
+                <code>ddgi</code>: open DuckDuckGo image search in a new tab or window with the given search term. Examples:<br/>
+                <code>ddgi pictures of mt everest</code>
+            </li>
+            <li>
+                <code>ddgv</code>: open DuckDuckGo video search in a new tab or window with the given search term. Examples:<br/>
+                <code>ddgv category theory</code><br/>
+            </li>
+            <li>
+                <code>ddgn</code>: open DuckDuckGo news search in a new tab or window with the given search term. Examples:<br/>
+                <code>ddgn market</code><br/>
+            </li>
+            <li>
+                <code>ddgm</code>: open DuckDuckGo maps search in a new tab or window with the given search term. Examples:<br/>
+                <code>ddgm coffee shop</code><br/>
+            </li>
+            <li>
                 <code>define</code>: find a dictionary definition for a word in English. Examples:<br/>
                 <code>define hello</code><br/>
                 <code>define coffee</code><br/>

--- a/src/rinseweb_manifests.erl
+++ b/src/rinseweb_manifests.erl
@@ -129,7 +129,7 @@ get_all() ->
             matches => [
                 #{
                     type => regex,
-                    value => <<"^(ddg)\s+(.*)$">>
+                    value => <<"^(ddg|ddgi|ddgv|ddgn|ddgm)\s+(.*)$">>
                 }
             ],
             handler => rinseweb_wiz_redirect

--- a/src/rinseweb_wiz_redirect.erl
+++ b/src/rinseweb_wiz_redirect.erl
@@ -11,6 +11,7 @@
 %% Types
 -type answer() :: #{
     url => binary(),
+    source => binary(),
     query => binary()
 }.
 
@@ -29,24 +30,25 @@
 -spec answer(rinseweb_wiz:question(), [any()]) -> rinseweb_wiz:answer().
 answer(_Question, [Command, Query]) ->
     QueryEncoded = rinseweb_util:url_encode(Query),
-    BaseUrl = command_to_base_url(Command),
+    {BaseUrl, Source} = command_to_url_and_source(Command),
     Url = <<BaseUrl/binary, QueryEncoded/binary>>,
-    rinseweb_wiz:answer(?ANSWER_TYPE, ?ANSWER_SOURCE, create_answer(Url, Query)).
+    rinseweb_wiz:answer(?ANSWER_TYPE, ?ANSWER_SOURCE, create_answer(Url, Source, Query)).
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
 
--spec command_to_base_url(binary()) -> binary().
-command_to_base_url(<<"ddg">>) -> ?URL_DDG_WEB;
-command_to_base_url(<<"ddgi">>) -> ?URL_DDG_IMG;
-command_to_base_url(<<"ddgv">>) -> ?URL_DDG_VID;
-command_to_base_url(<<"ddgn">>) -> ?URL_DDG_NEW;
-command_to_base_url(<<"ddgm">>) -> ?URL_DDG_MAP.
+-spec command_to_url_and_source(binary()) -> {binary(), binary()}.
+command_to_url_and_source(<<"ddg">>) -> {?URL_DDG_WEB, <<"DuckDuckGo">>};
+command_to_url_and_source(<<"ddgi">>) -> {?URL_DDG_IMG, <<"DuckDuckGo images">>};
+command_to_url_and_source(<<"ddgv">>) -> {?URL_DDG_VID, <<"DuckDuckGo videos">>};
+command_to_url_and_source(<<"ddgn">>) -> {?URL_DDG_NEW, <<"DuckDuckGo news">>};
+command_to_url_and_source(<<"ddgm">>) -> {?URL_DDG_MAP, <<"DuckDuckGo maps">>}.
 
--spec create_answer(binary(), binary()) -> answer().
-create_answer(Url, Query) ->
+-spec create_answer(binary(), binary(), binary()) -> answer().
+create_answer(Url, Source, Query) ->
     #{
         url => Url,
+        source => Source,
         query => Query
     }.

--- a/src/rinseweb_wiz_redirect.erl
+++ b/src/rinseweb_wiz_redirect.erl
@@ -16,21 +16,33 @@
 
 -define(ANSWER_SOURCE, redirect).
 -define(ANSWER_TYPE, redirect).
--define(URL_DDG, <<"https://duckduckgo.com/?t=rinseone&q=">>).
+-define(URL_DDG_WEB, <<"https://duckduckgo.com/?t=rinseone&q=">>).
+-define(URL_DDG_IMG, <<"https://duckduckgo.com/?t=rinseone&iax=images&ia=images&q=">>).
+-define(URL_DDG_VID, <<"https://duckduckgo.com/?t=rinseone&iax=videos&ia=videos&q=">>).
+-define(URL_DDG_NEW, <<"https://duckduckgo.com/?t=rinseone&iar=news&ia=news&q=">>).
+-define(URL_DDG_MAP, <<"https://duckduckgo.com/?t=rinseone&ia=news&iaxm=places&q=">>).
 
 %%====================================================================
 %% API
 %%====================================================================
 
 -spec answer(rinseweb_wiz:question(), [any()]) -> rinseweb_wiz:answer().
-answer(_Question, [<<"ddg">>, Query]) ->
+answer(_Question, [Command, Query]) ->
     QueryEncoded = rinseweb_util:url_encode(Query),
-    Url = <<?URL_DDG/binary, QueryEncoded/binary>>,
+    BaseUrl = command_to_base_url(Command),
+    Url = <<BaseUrl/binary, QueryEncoded/binary>>,
     rinseweb_wiz:answer(?ANSWER_TYPE, ?ANSWER_SOURCE, create_answer(Url, Query)).
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
+
+-spec command_to_base_url(binary()) -> binary().
+command_to_base_url(<<"ddg">>) -> ?URL_DDG_WEB;
+command_to_base_url(<<"ddgi">>) -> ?URL_DDG_IMG;
+command_to_base_url(<<"ddgv">>) -> ?URL_DDG_VID;
+command_to_base_url(<<"ddgn">>) -> ?URL_DDG_NEW;
+command_to_base_url(<<"ddgm">>) -> ?URL_DDG_MAP.
 
 -spec create_answer(binary(), binary()) -> answer().
 create_answer(Url, Query) ->

--- a/test/redirect_SUITE.erl
+++ b/test/redirect_SUITE.erl
@@ -45,12 +45,13 @@ end_per_testcase(_, _Config) ->
 %% Helpers
 %% ============================================================================
 
-result(Query, Url) ->
+result(Query, Source, Url) ->
     #{
         type => redirect,
         source => redirect,
         answer => #{
             url => Url,
+            source => Source,
             query => Query
         }
     }.
@@ -63,7 +64,7 @@ ddg(_) ->
     Command = <<"ddg">>,
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
-    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&q=", Query/binary>>),
+    ExpectedAnswer = result(Query, <<"DuckDuckGo">>, <<"https://duckduckgo.com/?t=rinseone&q=", Query/binary>>),
     Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
     ExpectedAnswer = Answer,
     ok.
@@ -72,7 +73,7 @@ ddgi(_) ->
     Command = <<"ddgi">>,
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
-    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&iax=images&ia=images&q=", Query/binary>>),
+    ExpectedAnswer = result(Query, <<"DuckDuckGo images">>, <<"https://duckduckgo.com/?t=rinseone&iax=images&ia=images&q=", Query/binary>>),
     Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
     ExpectedAnswer = Answer,
     ok.
@@ -81,7 +82,7 @@ ddgv(_) ->
     Command = <<"ddgv">>,
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
-    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&iax=videos&ia=videos&q=", Query/binary>>),
+    ExpectedAnswer = result(Query, <<"DuckDuckGo videos">>, <<"https://duckduckgo.com/?t=rinseone&iax=videos&ia=videos&q=", Query/binary>>),
     Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
     ExpectedAnswer = Answer,
     ok.
@@ -90,7 +91,7 @@ ddgn(_) ->
     Command = <<"ddgn">>,
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
-    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&iar=news&ia=news&q=", Query/binary>>),
+    ExpectedAnswer = result(Query, <<"DuckDuckGo news">>, <<"https://duckduckgo.com/?t=rinseone&iar=news&ia=news&q=", Query/binary>>),
     Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
     ExpectedAnswer = Answer,
     ok.
@@ -99,7 +100,7 @@ ddgm(_) ->
     Command = <<"ddgm">>,
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
-    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&ia=news&iaxm=places&q=", Query/binary>>),
+    ExpectedAnswer = result(Query, <<"DuckDuckGo maps">>, <<"https://duckduckgo.com/?t=rinseone&ia=news&iaxm=places&q=", Query/binary>>),
     Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
     ExpectedAnswer = Answer,
     ok.

--- a/test/redirect_SUITE.erl
+++ b/test/redirect_SUITE.erl
@@ -11,7 +11,10 @@
 
 %% Tests
 -export([ddg/1]).
+-export([ddgi/1]).
+-export([ddgv/1]).
 -export([ddgn/1]).
+-export([ddgm/1]).
 
 %% ============================================================================
 %% ct functions

--- a/test/redirect_SUITE.erl
+++ b/test/redirect_SUITE.erl
@@ -11,6 +11,7 @@
 
 %% Tests
 -export([ddg/1]).
+-export([ddgn/1]).
 
 %% ============================================================================
 %% ct functions
@@ -18,7 +19,11 @@
 
 all() ->
     [
-        ddg
+        ddg,
+        ddgi,
+        ddgv,
+        ddgn,
+        ddgm
     ].
 
 init_per_suite(Config) ->
@@ -56,6 +61,42 @@ ddg(_) ->
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
     ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&q=", Query/binary>>),
+    Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
+    ExpectedAnswer = Answer,
+    ok.
+
+ddgi(_) ->
+    Command = <<"ddg">>,
+    Query = <<"hello">>,
+    Question = <<Command/binary, " ", Query/binary>>,
+    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&iax=images&ia=images&q=", Query/binary>>),
+    Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
+    ExpectedAnswer = Answer,
+    ok.
+
+ddgv(_) ->
+    Command = <<"ddg">>,
+    Query = <<"hello">>,
+    Question = <<Command/binary, " ", Query/binary>>,
+    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&iax=videos&ia=videos&q=", Query/binary>>),
+    Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
+    ExpectedAnswer = Answer,
+    ok.
+
+ddgn(_) ->
+    Command = <<"ddgn">>,
+    Query = <<"hello">>,
+    Question = <<Command/binary, " ", Query/binary>>,
+    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&iar=news&ia=news&q=", Query/binary>>),
+    Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
+    ExpectedAnswer = Answer,
+    ok.
+
+ddgm(_) ->
+    Command = <<"ddg">>,
+    Query = <<"hello">>,
+    Question = <<Command/binary, " ", Query/binary>>,
+    ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&ia=news&iaxm=places&q=", Query/binary>>),
     Answer = rinseweb_wiz_redirect:answer(Question, [Command, Query]),
     ExpectedAnswer = Answer,
     ok.

--- a/test/redirect_SUITE.erl
+++ b/test/redirect_SUITE.erl
@@ -69,7 +69,7 @@ ddg(_) ->
     ok.
 
 ddgi(_) ->
-    Command = <<"ddg">>,
+    Command = <<"ddgi">>,
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
     ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&iax=images&ia=images&q=", Query/binary>>),
@@ -78,7 +78,7 @@ ddgi(_) ->
     ok.
 
 ddgv(_) ->
-    Command = <<"ddg">>,
+    Command = <<"ddgv">>,
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
     ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&iax=videos&ia=videos&q=", Query/binary>>),
@@ -96,7 +96,7 @@ ddgn(_) ->
     ok.
 
 ddgm(_) ->
-    Command = <<"ddg">>,
+    Command = <<"ddgm">>,
     Query = <<"hello">>,
     Question = <<Command/binary, " ", Query/binary>>,
     ExpectedAnswer = result(Query, <<"https://duckduckgo.com/?t=rinseone&ia=news&iaxm=places&q=", Query/binary>>),

--- a/test/redirect_web_SUITE.erl
+++ b/test/redirect_web_SUITE.erl
@@ -38,7 +38,7 @@ end_per_testcase(_, _Config) ->
 %% Helpers
 %% ============================================================================
 
-result(Question, Url, Query) ->
+result(Question, Query, Source, Url) ->
     #{
         <<"question">> => list_to_binary(Question),
         <<"answers">> => [
@@ -47,6 +47,7 @@ result(Question, Url, Query) ->
                 <<"type">> => <<"redirect">>,
                 <<"answer">> => #{
                     <<"url">> => Url,
+                    <<"source">> => Source,
                     <<"query">> => Query
                 }
             }
@@ -62,7 +63,7 @@ ddg(_) ->
     {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
     Response = rinseweb_test:decode_response_body(ResponseBody),
     true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"https://duckduckgo.com/?t=rinseone&q=hello">>, <<"hello">>),
+    ExpectedResponse = result(Question, <<"hello">>, <<"DuckDuckGo">>, <<"https://duckduckgo.com/?t=rinseone&q=hello">>),
     ExpectedResponse = Response,
     ok.
 
@@ -71,6 +72,6 @@ ddg_encode_query(_) ->
     {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
     Response = rinseweb_test:decode_response_body(ResponseBody),
     true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"https://duckduckgo.com/?t=rinseone&q=hello%20%26%20goodbye">>, <<"hello & goodbye">>),
+    ExpectedResponse = result(Question, <<"hello & goodbye">>, <<"DuckDuckGo">>, <<"https://duckduckgo.com/?t=rinseone&q=hello%20%26%20goodbye">>),
     ExpectedResponse = Response,
     ok.


### PR DESCRIPTION
## Description

Adds new commands `ddgi`, `ddgv`, `ddgn` and `ddgm` to redirect to DuckDuckGo images, videos, news and maps searches respectively.