### PR TITLE
Expose commands in text input

### DIFF
--- a/priv/static/assets/root.css
+++ b/priv/static/assets/root.css
@@ -1,6 +1,6 @@
 h2 {font-size:5em;font-family:monospace;}
 form#search {display:flex;justify-content:center;}
-input[type="text"] {font-size:3em;}
+input[type="search"] {font-size:3em;}
 div#answer {font-size:3em;font-family:sans-serif;width:80%;margin-left:auto;margin-right:auto;}
 div#answer > div.simple {text-align:center;}
 div#answer > ul {margin:0;padding:0;list-style-type:none;font-size:0.5em;}

--- a/src/rinseweb_h_root.erl
+++ b/src/rinseweb_h_root.erl
@@ -42,7 +42,23 @@ hello_to_html(Req, State) ->
     <div>
         <h2 style=\"text-align:center;\"><span style=\"color:#0f2557\">r</span><span style=\"color:#28559a\">i</span><span style=\"color:#3778c2\">n</span><span style=\"color:#4b9fe1\">s</span><span style=\"color:#63bce5\">e</span></h2>
         <form id=\"search\">
-            <input id=\"question\" type=\"text\" autocapitalize=\"none\" size=\"30\" style=\"text-align:center\" />
+            <input id=\"question\" list=\"commands\" type=\"search\" autocapitalize=\"none\" size=\"30\" style=\"text-align:center\" />
+            <datalist id=\"commands\">
+                <option value=\"convert \"/>
+                <option value=\"ddg \"/>
+                <option value=\"ddgi \"/>
+                <option value=\"ddgm \"/>
+                <option value=\"ddgn \"/>
+                <option value=\"ddgv \"/>
+                <option value=\"define \"/>
+                <option value=\"md5 \"/>
+                <option value=\"now \"/>
+                <option value=\"sha \"/>
+                <option value=\"sha2 \"/>
+                <option value=\"uuid\"/>
+                <option value=\"wiki \"/>
+                <option value=\"how to \"/>
+            </datalist>
         </form>
         <br/><br/>
         <div id=\"results\">


### PR DESCRIPTION
## Description

This change exposes the static list of available commands while typing in the input text box. To do this, the input is converted from `text` to `search` and `datalist` HTML element is added with the static list of existing supported commands.