### PR TITLE
Add error reasons

### DIFF
--- a/priv/static/assets/app.js
+++ b/priv/static/assets/app.js
@@ -132,6 +132,11 @@ function answerToNode(answer) {
             node.appendChild(linkNode);
             window.open(url, '_blank');
             break;
+        case "shrug":
+            node = document.createElement('div');
+            node.setAttribute('class', 'error');
+            node.appendChild(document.createTextNode(answer.answer));
+            break;
         default:
             node = document.createTextNode("");
     };

--- a/priv/static/assets/root.css
+++ b/priv/static/assets/root.css
@@ -2,6 +2,7 @@ h2 {font-size:5em;font-family:monospace;}
 form#search {display:flex;justify-content:center;}
 input[type="search"] {font-size:3em;}
 div#answer {font-size:3em;font-family:sans-serif;width:80%;margin-left:auto;margin-right:auto;}
+div#answer > div.error {text-align:center;font-size:0.7em;}
 div#answer > div.simple {text-align:center;}
 div#answer > ul {margin:0;padding:0;list-style-type:none;font-size:0.5em;}
 div#answer > ul.wiki > li {white-space:nowrap;overflow:hidden;text-overflow:clip;margin:10px;}

--- a/src/rinseweb_be_wiki.erl
+++ b/src/rinseweb_be_wiki.erl
@@ -34,7 +34,7 @@ search(BaseUri, Query) ->
     Items.
 
 -spec items_to_answer(rinseweb_wiz:answer_source(), [item()]) -> rinseweb_wiz:anwer().
-items_to_answer(Source, []) -> rinseweb_wiz:shrug(Source);
+items_to_answer(Source, []) -> rinseweb_wiz:shrug(Source, <<"No results">>);
 items_to_answer(Source, Items) -> rinseweb_wiz:answer(?TYPE, Source, Items).
 
 %%====================================================================

--- a/src/rinseweb_h_answer.erl
+++ b/src/rinseweb_h_answer.erl
@@ -72,7 +72,6 @@ answer_to_text(Req, State) ->
 %% Internal functions
 %%====================================================================
 
-result_to_binary(#{answers := []}) -> unicode:characters_to_binary("¯\\_(ツ)_/¯");
 result_to_binary(#{answers := [#{type := Type, answer := AnswerCustom}|_]}) ->
     answer_to_binary(Type, AnswerCustom).
 

--- a/src/rinseweb_h_answer.erl
+++ b/src/rinseweb_h_answer.erl
@@ -76,6 +76,7 @@ result_to_binary(#{answers := [#{type := Type, answer := AnswerCustom}|_]}) ->
     answer_to_binary(Type, AnswerCustom).
 
 -spec answer_to_binary(atom(), map()) -> binary().
+answer_to_binary(shrug, Reason) -> Reason;
 answer_to_binary(text, #{text := Text}) -> Text;
 answer_to_binary(hash, #{hash := Hash}) -> Hash;
 answer_to_binary(conversion_result, AnswerCustom) ->

--- a/src/rinseweb_wiz.erl
+++ b/src/rinseweb_wiz.erl
@@ -42,7 +42,7 @@ answer(Question) ->
     TrimmedQuestion = binary_max_size(rinseweb_util:binary_trim(Question), 128),
     {Manifest, Args} = find_handler(TrimmedQuestion, rinseweb_manifests:get_all()),
     Answer = handler_answer(Manifest, TrimmedQuestion, Args),
-    Answers = maybe_add_answer(Answer, []),
+    Answers = [Answer],
     #{
         question => TrimmedQuestion,
         answers => Answers
@@ -122,10 +122,6 @@ handler_answer(#{handler := Handler, cache := _CacheOptions}, Question, Args) ->
     end;
 handler_answer(#{handler := Handler}, Question, Args) ->
     Handler:answer(Question, Args).
-
--spec maybe_add_answer(answer(), answers()) -> answers().
-maybe_add_answer(#{type := shrug}, Answers) -> Answers;
-maybe_add_answer(Answer, Answers) -> [Answer|Answers].
 
 -spec binary_max_size(binary(), pos_integer()) -> binary().
 binary_max_size(Bin, Size) when byte_size(Bin) =< Size -> Bin;

--- a/src/rinseweb_wiz.erl
+++ b/src/rinseweb_wiz.erl
@@ -10,7 +10,7 @@
 -export([answer/3]).
 -export([answer_number/3]).
 -export([answer_text/3]).
--export([shrug/1]).
+-export([shrug/2]).
 
 %% Types
 -type result() :: #{
@@ -70,11 +70,12 @@ answer_number(Type, Source, Num) ->
     },
     answer(Type, Source, AnswerCustom).
 
--spec shrug(answer_source()) -> answer().
-shrug(Source) ->
+-spec shrug(answer_source(), binary()) -> answer().
+shrug(Source, Text) ->
     #{
         type => shrug,
-        source => Source
+        source => Source,
+        answer => Text
     }.
 
 %%====================================================================

--- a/src/rinseweb_wiz_apply.erl
+++ b/src/rinseweb_wiz_apply.erl
@@ -30,16 +30,17 @@ answer(_Question, [Operator, OperandsBin, _]) ->
 %% Internal functions
 %%====================================================================
 
--spec answer(result() | undefined) -> rinseweb_wiz:answer().
-answer(undefined) -> rinseweb_wiz:shrug(?ANSWER_SOURCE);
+-spec answer(result() | {error, binary()}) -> rinseweb_wiz:answer().
+answer({error, Reason}) -> rinseweb_wiz:shrug(?ANSWER_SOURCE, Reason);
 answer(Num) ->
     rinseweb_wiz:answer_number(?ANSWER_TYPE, ?ANSWER_SOURCE, Num).
 
--spec parse_operator(binary()) -> operator().
+-spec parse_operator(binary()) -> operator() | {error, binary()}.
 parse_operator(<<"+">>) -> '+';
 parse_operator(<<"-">>) -> '-';
 parse_operator(<<"/">>) -> '/';
-parse_operator(<<"*">>) -> '*'.
+parse_operator(<<"*">>) -> '*';
+parse_operator(_) -> {error, <<"Unknown operator">>}.
 
 -spec parse_operands([binary()]) -> [operand()].
 parse_operands(BinOpList) ->
@@ -54,12 +55,12 @@ parse_operands([BinOp|Rest], Acc) ->
 parse_operand(BinOp) ->
     rinseweb_util:round_precise(rinseweb_util:binary_to_number(BinOp)).
 
--spec apply_op(operator(), [operand()]) -> result() | undefined.
+-spec apply_op(operator() | {error, binary()}, [operand()]) -> result() | {error, binary()}.
 apply_op('+', Operands) -> lists:sum(Operands);
 apply_op('-', [First|Rest]) -> apply_op_sub(First, Rest);
 apply_op('*', [First|Rest]) -> apply_op_mul(First, Rest);
 apply_op('/', [First|Rest]) -> apply_op_div(First, Rest);
-apply_op(_, _) -> undefined.
+apply_op({error, Reason}, _) -> {error, Reason}.
 
 -spec apply_op_sub(operand(), [operand()]) -> result().
 apply_op_sub(Result, []) -> Result;

--- a/src/rinseweb_wiz_convert.erl
+++ b/src/rinseweb_wiz_convert.erl
@@ -9,11 +9,12 @@
 -export([answer/2]).
 
 %% Types
--type unit_or_unknown() :: binary() | unknown.
+-type unit_or_unknown() :: binary() | {unknown, binary()}.
 -type unit() :: binary().
 
 -define(ANSWER_SOURCE, convert).
 -define(ANSWER_TYPE, conversion_result).
+-define(UNIT_MAX_LENGTH_BYTES, 30).
 
 %%====================================================================
 %% API
@@ -21,8 +22,8 @@
 
 -spec answer(rinseweb_wiz:question(), [any()]) -> rinseweb_wiz:answer().
 answer(_Question, [FromNumBin, FromUnitBin, ToUnitBin]) ->
-    FromUnit= binary_to_canonical_unit(FromUnitBin),
-    ToUnit= binary_to_canonical_unit(ToUnitBin),
+    FromUnit = binary_to_canonical_unit(FromUnitBin),
+    ToUnit = binary_to_canonical_unit(ToUnitBin),
     answer_using_canonical_units(FromNumBin, FromUnit, ToUnit).
 
 %%====================================================================
@@ -30,15 +31,15 @@ answer(_Question, [FromNumBin, FromUnitBin, ToUnitBin]) ->
 %%====================================================================
 
 -spec answer_using_canonical_units(binary(), unit_or_unknown(), unit_or_unknown()) -> rinseweb_wiz:answer().
-answer_using_canonical_units(_, unknown, _) -> rinseweb_wiz:shrug(?ANSWER_SOURCE);
-answer_using_canonical_units(_, _, unknown) -> rinseweb_wiz:shrug(?ANSWER_SOURCE);
+answer_using_canonical_units(_, {unknown, Unit}, _) -> rinseweb_wiz:shrug(?ANSWER_SOURCE, <<"Unknown unit '", Unit/binary, "'">>);
+answer_using_canonical_units(_, _, {unknown, Unit}) -> rinseweb_wiz:shrug(?ANSWER_SOURCE, <<"Unknown unit '", Unit/binary, "'">>);
 answer_using_canonical_units(FromNumBin, FromUnit, ToUnit) ->
     FromNum = rinseweb_util:round_precise(rinseweb_util:binary_to_number(FromNumBin)),
     ConversionResult = convert(FromNum, FromUnit, ToUnit),
     answer_conversion_result(FromNum, FromUnit, ToUnit, ConversionResult).
 
--spec answer_conversion_result(number(), unit(), unit(), undefined | number()) -> rinseweb_wiz:answer().
-answer_conversion_result(_, _, _, undefined) -> rinseweb_wiz:shrug(?ANSWER_SOURCE);
+-spec answer_conversion_result(number(), unit(), unit(), {error, binary()} | number()) -> rinseweb_wiz:answer().
+answer_conversion_result(_, _, _, {error, Error}) -> rinseweb_wiz:shrug(?ANSWER_SOURCE, Error);
 answer_conversion_result(FromNum, FromUnit, ToUnit, ToNum) ->
     AnswerCustom = #{
         unit_from_name => FromUnit,
@@ -48,7 +49,7 @@ answer_conversion_result(FromNum, FromUnit, ToUnit, ToNum) ->
     },
     rinseweb_wiz:answer(?ANSWER_TYPE, ?ANSWER_SOURCE, AnswerCustom).
 
--spec convert(number(), unit(), unit()) -> number() | undefined.
+-spec convert(number(), unit(), unit()) -> number() | {error, binary()}.
 convert(Num, FromUnit, ToUnit) ->
     Command = "units --terse",
     FromArg = units_from_arg(Num, FromUnit),
@@ -69,10 +70,10 @@ unit_arg(<<"celsius">>) -> "tempC";
 unit_arg(<<"fahrenheit">>) -> "tempF";
 unit_arg(UnitBin) when is_binary(UnitBin) -> binary_to_list(UnitBin).
 
--spec string_to_number(string()) -> number() | undefined.
-string_to_number("conformability error") -> undefined;
-string_to_number([$U,$n,$k,$n,$o,$w,$n|_]) -> undefined; % Handles "Unknown unit 'foo'" error
-string_to_number([$E,$r,$r,$o,$r|_]) -> undefined; % Handles "Error in 'foo': Parse error" error
+-spec string_to_number(string()) -> number() | {error, binary()}.
+string_to_number("conformability error") -> {error, <<"Unable to convert between non-conforming units">>};
+string_to_number([$U,$n,$k,$n,$o,$w,$n,32,$u,$n,$i,$t,32|_] = Error) -> {error, list_to_binary(Error)}; % Handles "Unknown unit 'foo'" error
+string_to_number([$E,$r,$r,$o,$r|_] = Error) -> {error, list_to_binary(Error)}; % Handles "Error in 'foo': Parse error" error
 string_to_number(S) -> rinseweb_util:string_to_number(S).
 
 -spec number_to_list(number()) -> list().
@@ -84,9 +85,12 @@ binary_to_canonical_unit(<<"c">>) -> <<"celsius">>;
 binary_to_canonical_unit(<<"celsius">>) -> <<"celsius">>;
 binary_to_canonical_unit(<<"f">>) -> <<"fahrenheit">>;
 binary_to_canonical_unit(<<"fahrenheit">>) -> <<"fahrenheit">>;
+binary_to_canonical_unit(UnitBin) when byte_size(UnitBin) > ?UNIT_MAX_LENGTH_BYTES ->
+    validate_unit(nomatch, UnitBin);
 binary_to_canonical_unit(UnitBin) ->
     validate_unit(re:run(UnitBin, <<"^[a-zA-Z]+[\\^]?[2-3]?$">>, [{capture, none}]), UnitBin).
 
 -spec validate_unit(atom(), binary()) -> unit_or_unknown().
-validate_unit(match, Unit) when byte_size(Unit) < 30 -> Unit;
-validate_unit(nomatch, _Unit) -> unknown.
+validate_unit(match, Unit) when byte_size(Unit) < ?UNIT_MAX_LENGTH_BYTES -> Unit;
+validate_unit(nomatch, <<UnitSub:30/binary,_/binary>> = Unit) when byte_size(Unit) > ?UNIT_MAX_LENGTH_BYTES -> {unknown, UnitSub};
+validate_unit(nomatch, Unit) -> {unknown, Unit}.

--- a/src/rinseweb_wiz_default.erl
+++ b/src/rinseweb_wiz_default.erl
@@ -16,5 +16,6 @@
 answer(_Question, _Args) ->
     #{
         type => shrug,
-        source => default
+        source => default,
+        answer => <<"Unrecognized command">>
     }.

--- a/src/rinseweb_wiz_dictionaryapi.erl
+++ b/src/rinseweb_wiz_dictionaryapi.erl
@@ -58,13 +58,19 @@ search(Query) ->
 parse_response({error, _Reason}) -> rinseweb_wiz:shrug(?SOURCE, <<"Error querying dictionary">>);
 parse_response({ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}}) ->
     BodyDecoded = jsx:decode(Body, [{return_maps, true}]),
-    rinseweb_wiz:answer(?TYPE, ?SOURCE, parse_body(BodyDecoded));
+    answer_or_shrug(parse_body(BodyDecoded));
+parse_response({ok, {{_Version, 404, _ReasonPhrase}, _Headers, _Body}}) ->
+    rinseweb_wiz:shrug(?SOURCE, <<"Definition not found">>);
 parse_response({ok, {{_Version, _Status, _ReasonPhrase}, _Headers, _Body}}) ->
     rinseweb_wiz:shrug(?SOURCE, <<"Error response from dictionary">>).
 
 -spec parse_body(list()) -> [item()].
 parse_body(ListOfItems) ->
     lists:reverse(parse_body(ListOfItems, [])).
+
+-spec answer_or_shrug([item()]) -> rinseweb_wiz:answer().
+answer_or_shrug([]) -> rinseweb_wiz:shrug(?SOURCE, <<"Definition not found">>);
+answer_or_shrug(ParsedItems) -> rinseweb_wiz:answer(?TYPE, ?SOURCE, ParsedItems).
 
 -spec parse_body(list(), [item()]) -> [item()].
 parse_body([], Acc) -> Acc;

--- a/src/rinseweb_wiz_dictionaryapi.erl
+++ b/src/rinseweb_wiz_dictionaryapi.erl
@@ -55,12 +55,12 @@ search(Query) ->
     parse_response(Response).
 
 -spec parse_response({ok, {httpc:status_line(), httpc:headers(), binary()}} | {error, term()}) -> rinseweb_wiz:answer().
-parse_response({error, _Reason}) -> rinseweb_wiz:shrug(?SOURCE);
+parse_response({error, _Reason}) -> rinseweb_wiz:shrug(?SOURCE, <<"Error querying dictionary">>);
 parse_response({ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}}) ->
     BodyDecoded = jsx:decode(Body, [{return_maps, true}]),
     rinseweb_wiz:answer(?TYPE, ?SOURCE, parse_body(BodyDecoded));
 parse_response({ok, {{_Version, _Status, _ReasonPhrase}, _Headers, _Body}}) ->
-    rinseweb_wiz:shrug(?SOURCE).
+    rinseweb_wiz:shrug(?SOURCE, <<"Error response from dictionary">>).
 
 -spec parse_body(list()) -> [item()].
 parse_body(ListOfItems) ->

--- a/test/apply_SUITE.erl
+++ b/test/apply_SUITE.erl
@@ -14,6 +14,7 @@
 -export([subtract/1]).
 -export([multiply/1]).
 -export([divide/1]).
+-export([unknown_operator/1]).
 
 %% ============================================================================
 %% ct functions
@@ -24,7 +25,8 @@ all() ->
         add,
         subtract,
         multiply,
-        divide
+        divide,
+        unknown_operator
     ].
 
 init_per_suite(Config) ->
@@ -70,3 +72,10 @@ divide(_) ->
     number = maps:get(type, Answer),
     apply = maps:get(source, Answer),
     0.5 = maps:get(number, maps:get(answer, Answer)).
+
+unknown_operator(_) ->
+    Question = <<"^ 1 2 3">>,
+    Answer = rinseweb_wiz_apply:answer(Question, [<<"^">>, <<" 1 2 3">>, <<" 3">>]),
+    shrug = maps:get(type, Answer),
+    apply = maps:get(source, Answer),
+    <<"Unknown operator">> = maps:get(answer, Answer).

--- a/test/base_SUITE.erl
+++ b/test/base_SUITE.erl
@@ -42,7 +42,13 @@ max_question_length(_) ->
     QuestionMax = binary:copy(<<"a">>, 128),
     ExpectedAnswer = #{
         question => QuestionMax,
-        answers => []
+        answers => [
+            #{
+                answer => <<"Unrecognized command">>,
+                source => default,
+                type => shrug
+            }
+        ]
     },
     Answer = rinseweb_wiz:answer(QuestionLong),
     ExpectedAnswer = Answer,

--- a/test/convert_SUITE.erl
+++ b/test/convert_SUITE.erl
@@ -92,16 +92,17 @@ unit_coverage(_) ->
 
 unit_invalid(_) ->
     TestCases = [
-        {<<"kg">>, <<"foo">>},
-        {<<"foo">>, <<"kg">>},
-        {<<"foo">>, <<"bar">>},
-        {<<"kg">>, <<"mm">>},
-        {<<"meters^2">>, <<"^2">>}
+        {<<"kg">>, <<"foo">>, <<"Unknown unit 'foo'">>},
+        {<<"foo">>, <<"kg">>, <<"Unknown unit 'foo'">>},
+        {<<"foo">>, <<"bar">>, <<"Unknown unit 'foo'">>},
+        {<<"kg">>, <<"1234567890123456789012345678901">>, <<"Unknown unit '123456789012345678901234567890'">>},
+        {<<"kg">>, <<"mm">>, <<"Unable to convert between non-conforming units">>},
+        {<<"meters^2">>, <<"m^">>, <<"Error in 'm^': Parse error">>}
     ],
-    ExpectedAnswer = rinseweb_wiz:shrug(convert),
     UnitNum = <<"1">>,
-    F = fun({UnitFrom, UnitTo}, Acc) ->
+    F = fun({UnitFrom, UnitTo, ErrorReason}, Acc) ->
             Question = <<"convert ", UnitNum/binary, UnitFrom/binary, " to ", UnitTo/binary>>,
+            ExpectedAnswer = rinseweb_wiz:shrug(convert, ErrorReason),
             ExpectedAnswer = rinseweb_wiz_convert:answer(Question, [UnitNum, UnitFrom, UnitTo]),
             Acc
         end,

--- a/test/convert_web_SUITE.erl
+++ b/test/convert_web_SUITE.erl
@@ -50,8 +50,16 @@ end_per_testcase(_, _Config) ->
 %% Helpers
 %% ============================================================================
 
-result_no_answers(Question) when is_list(Question) ->
-    result_custom_answers(Question, []).
+result_shrug(Question) when is_list(Question) ->
+    result_shrug(Question, <<"Unrecognized command">>, <<"default">>).
+
+result_shrug(Question, Reason, Source) when is_list(Question) ->
+    Shrug = #{
+        <<"answer">> => Reason,
+        <<"source">> => Source,
+        <<"type">> => <<"shrug">>
+    },
+    result_custom_answers(Question, [Shrug]).
 
 result_custom_answers(Question, Answers) ->
     #{
@@ -113,7 +121,7 @@ convert_unrecognized_syntax(_) ->
     {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
     Response = rinseweb_test:decode_response_body(ResponseBody),
     true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result_no_answers(Question),
+    ExpectedResponse = result_shrug(Question),
     ExpectedResponse = Response,
     ok.
 
@@ -122,7 +130,7 @@ convert_unsupported_unit(_) ->
     {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
     Response = rinseweb_test:decode_response_body(ResponseBody),
     true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result_no_answers(Question),
+    ExpectedResponse = result_shrug(Question, <<"Unknown unit 'jujumeters'">>, <<"convert">>),
     ExpectedResponse = Response,
     ok.
 
@@ -136,7 +144,7 @@ convert_invalid_number(_) ->
             {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
             Response = rinseweb_test:decode_response_body(ResponseBody),
             true = lists:member({"content-type","application/json"}, Headers),
-            ExpectedResponse = result_no_answers(Question),
+            ExpectedResponse = result_shrug(Question),
             ExpectedResponse = Response,
             Acc
         end,

--- a/test/dicrionaryapi_SUITE.erl
+++ b/test/dicrionaryapi_SUITE.erl
@@ -49,4 +49,3 @@ query(_) ->
     true = maps:is_key(word, FirstItem),
     true = maps:is_key(phonetics, FirstItem),
     true = maps:is_key(meanings, FirstItem).
-

--- a/test/dictionaryapi_web_SUITE.erl
+++ b/test/dictionaryapi_web_SUITE.erl
@@ -55,4 +55,3 @@ query(_) ->
     true = maps:is_key(<<"phonetics">>, FirstItem),
     true = maps:is_key(<<"meanings">>, FirstItem),
     ok.
-


### PR DESCRIPTION
## Description

When wizards return an error, instead of simply returning a `shrug` atom, they can now return an arbitrary binary reason. All of them are modified and tests updated.