### PR TITLE
Switch default branch to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ rel: all
 release: set-version
 	git commit -a -m "Update version to $(version)"
 	git tag $(version)
-	git push --atomic origin master $(version)
+	git push --atomic origin main $(version)
 
 run:
 	@$(REBAR3) shell

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ Update version to prepare for release; for example, to set version `1.2.3`, tag 
 make set-version version=1.2.3
 git commit -a -m "Update version to 1.2.3"
 git tag 1.2.3
-git push --atomic origin master 1.2.3
+git push --atomic origin main 1.2.3
 ```


### PR DESCRIPTION
## Description

Update default branch to `main` - Makefile and readme updated with the new `main` branch name references.