### PR TITLE
Add option to run service on arbitrary port

### DIFF
--- a/src/rinseweb_app.erl
+++ b/src/rinseweb_app.erl
@@ -19,7 +19,8 @@ start(_StartType, _StartArgs) ->
             {"/assets/[...]", cowboy_static, {priv_dir, rinseweb, "static/assets"}}
         ]}
     ]),
-    {ok, _} = cowboy:start_clear(http, [{port, 8080}], #{
+    Port = rinseweb_env:port(),
+    {ok, _} = cowboy:start_clear(http, [{port, Port}], #{
         env => #{dispatch => Dispatch}
     }),
     ok = init_cache(),

--- a/src/rinseweb_env.erl
+++ b/src/rinseweb_env.erl
@@ -1,0 +1,12 @@
+%%%-------------------------------------------------------------------
+%% @doc rinseweb environment
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(rinseweb_env).
+
+-export([port/0]).
+
+-spec port() -> integer().
+port() ->
+    list_to_integer(os:getenv("RINSEWEB_PORT", "8080")).

--- a/test/base_web_SUITE.erl
+++ b/test/base_web_SUITE.erl
@@ -45,19 +45,19 @@ end_per_testcase(_, _Config) ->
 %% ============================================================================
 
 web_root_response_contains_form(_) ->
-    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, ResponseBody}} = httpc:request("http://localhost:8080"),
+    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, ResponseBody}} = httpc:request(rinseweb_test:base_uri()),
     FoundPos = string:str(ResponseBody, "<form id=\"search\">"),
     true = FoundPos > 0,
     ok.
 
 web_app_js_loads(_) ->
-    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request("http://localhost:8080/assets/app.js"),
+    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request(rinseweb_test:base_uri() ++ "/assets/app.js"),
     ok.
 
 web_about_page_loads(_) ->
-    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request("http://localhost:8080/about"),
+    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request(rinseweb_test:base_uri() ++ "/about"),
     ok.
 
 web_commands_page_loads(_) ->
-    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request("http://localhost:8080/commands"),
+    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, _ResponseBody}} = httpc:request(rinseweb_test:base_uri() ++ "/commands"),
     ok.

--- a/test/rinseweb_test.erl
+++ b/test/rinseweb_test.erl
@@ -1,6 +1,7 @@
 -module(rinseweb_test).
 
 %% API
+-export([base_uri/0]).
 -export([question_uri/1]).
 -export([request_json/1]).
 -export([decode_response_body/1]).
@@ -9,8 +10,12 @@
 %% API
 %%====================================================================
 
+base_uri() ->
+    Port = integer_to_list(rinseweb_env:port()),
+    "http://localhost:" ++ Port.
+
 question_uri(Question) ->
-    "http://localhost:8080/answer/" ++ edoc_lib:escape_uri(Question).
+     base_uri() ++ "/answer/" ++ edoc_lib:escape_uri(Question).
 
 request_json(Question) ->
     Request = {question_uri(Question), [{"Accept", "application/json"}]},


### PR DESCRIPTION
## Description

Make port configurable via an environment variable `RINSEWEB_PORT`, defaulting to currently hardcoded `8080`.