### PR TITLE
Update Erlang/OTP version in github release workflow to 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04 # same as ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Erlang
         uses: erlef/setup-beam@v1
         with:
-          # https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_24.3.3-1~ubuntu~focal_amd64.deb
-          otp-version: 24.3.3
+          # https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_25.0.3-1~ubuntu~focal_amd64.deb
+          otp-version: 25.0.3
       - name: Install units
         run: sudo apt install units
       - name: Test


### PR DESCRIPTION
## Description

Updates Erlang/OTP version to 25 - followup to #39.