### PR TITLE
Avoid repetition in web test suites

### DIFF
--- a/test/apply_web_SUITE.erl
+++ b/test/apply_web_SUITE.erl
@@ -41,53 +41,42 @@ end_per_testcase(_, _Config) ->
     ok.
 
 %% ============================================================================
+%% Helpers
+%% ============================================================================
+
+expected_answer(Number) ->
+    #{
+        <<"source">> => <<"apply">>,
+        <<"type">> => <<"number">>,
+        <<"answer">> => #{
+            <<"number">> => Number
+        }
+    }.
+
+%% ============================================================================
 %% Tests
 %% ============================================================================
 
 add(_) ->
-    Question = "+ 1 2 3",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
-    <<"number">> = maps:get(<<"type">>, Answer),
-    6 = maps:get(<<"number">>, maps:get(<<"answer">>, Answer)),
+    Answer = rinseweb_test:request_and_decode_answer("+ 1 2 3"),
+    ExpectedAnswer = expected_answer(6),
+    ExpectedAnswer = Answer,
     ok.
 
 subtract(_) ->
-    Question = "- 1 2 3",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
-    <<"number">> = maps:get(<<"type">>, Answer),
-    -4 = maps:get(<<"number">>, maps:get(<<"answer">>, Answer)),
+    Answer = rinseweb_test:request_and_decode_answer("- 1 2 3"),
+    ExpectedAnswer = expected_answer(-4),
+    ExpectedAnswer = Answer,
     ok.
 
 multiply(_) ->
-    Question = "* 1 2 3",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
-    <<"number">> = maps:get(<<"type">>, Answer),
-    6 = maps:get(<<"number">>, maps:get(<<"answer">>, Answer)),
+    Answer = rinseweb_test:request_and_decode_answer("* 1 2 3"),
+    ExpectedAnswer = expected_answer(6),
+    ExpectedAnswer = Answer,
     ok.
 
 divide(_) ->
-    Question = "/ 4 2 2 2",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
-    <<"number">> = maps:get(<<"type">>, Answer),
-    0.5 = maps:get(<<"number">>, maps:get(<<"answer">>, Answer)),
+    Answer = rinseweb_test:request_and_decode_answer("/ 4 2 2 2"),
+    ExpectedAnswer = expected_answer(0.5),
+    ExpectedAnswer = Answer,
     ok.

--- a/test/dictionaryapi_web_SUITE.erl
+++ b/test/dictionaryapi_web_SUITE.erl
@@ -39,13 +39,7 @@ end_per_testcase(_, _Config) ->
 %% ============================================================================
 
 query(_) ->
-    Question = "define hello",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    Answer = rinseweb_test:request_and_decode_answer("define hello"),
     <<"definition">> = maps:get(<<"type">>, Answer),
     AnswerCustom = maps:get(<<"answer">>, Answer),
     true = is_list(AnswerCustom),

--- a/test/hash_web_SUITE.erl
+++ b/test/hash_web_SUITE.erl
@@ -44,18 +44,13 @@ end_per_testcase(_, _Config) ->
 %% Helpers
 %% ============================================================================
 
-result(Question, Hash) ->
+expected_answer(Hash) ->
     #{
-        <<"question">> => list_to_binary(Question),
-        <<"answers">> => [
-            #{
-                <<"source">> => <<"hash">>,
-                <<"type">> => <<"hash">>,
-                <<"answer">> => #{
-                    <<"hash">> => Hash
-                }
-            }
-        ]
+        <<"source">> => <<"hash">>,
+        <<"type">> => <<"hash">>,
+        <<"answer">> => #{
+            <<"hash">> => Hash
+        }
     }.
 
 %% ============================================================================
@@ -63,37 +58,25 @@ result(Question, Hash) ->
 %% ============================================================================
 
 sha(_) ->
-    Question = "sha hello",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    Response = rinseweb_test:decode_response_body(ResponseBody),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d">>),
-    ExpectedResponse = Response,
+    Answer = rinseweb_test:request_and_decode_answer("sha hello"),
+    ExpectedAnswer = expected_answer(<<"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d">>),
+    ExpectedAnswer = Answer,
     ok.
 
 sha2(_) ->
-    Question = "sha2 hello",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    Response = rinseweb_test:decode_response_body(ResponseBody),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824">>),
-    ExpectedResponse = Response,
+    Answer = rinseweb_test:request_and_decode_answer("sha2 hello"),
+    ExpectedAnswer = expected_answer(<<"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824">>),
+    ExpectedAnswer = Answer,
     ok.
 
 md5(_) ->
-    Question = "md5 hello",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    Response = rinseweb_test:decode_response_body(ResponseBody),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"5d41402abc4b2a76b9719d911017c592">>),
-    ExpectedResponse = Response,
+    Answer = rinseweb_test:request_and_decode_answer("md5 hello"),
+    ExpectedAnswer = expected_answer(<<"5d41402abc4b2a76b9719d911017c592">>),
+    ExpectedAnswer = Answer,
     ok.
 
 separator_greedy_match(_) ->
-    Question = "md5         hello",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    Response = rinseweb_test:decode_response_body(ResponseBody),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"5d41402abc4b2a76b9719d911017c592">>),
-    ExpectedResponse = Response,
+    Answer = rinseweb_test:request_and_decode_answer("md5         hello"),
+    ExpectedAnswer = expected_answer(<<"5d41402abc4b2a76b9719d911017c592">>),
+    ExpectedAnswer = Answer,
     ok.

--- a/test/redirect_web_SUITE.erl
+++ b/test/redirect_web_SUITE.erl
@@ -11,6 +11,7 @@
 
 %% Tests
 -export([ddg/1]).
+-export([ddg_encode_query/1]).
 
 %% ============================================================================
 %% ct functions
@@ -18,7 +19,8 @@
 
 all() ->
     [
-        ddg
+        ddg,
+        ddg_encode_query
     ].
 
 init_per_suite(Config) ->
@@ -38,20 +40,15 @@ end_per_testcase(_, _Config) ->
 %% Helpers
 %% ============================================================================
 
-result(Question, Query, Source, Url) ->
+expected_answer(Query, Source, Url) ->
     #{
-        <<"question">> => list_to_binary(Question),
-        <<"answers">> => [
-            #{
-                <<"source">> => <<"redirect">>,
-                <<"type">> => <<"redirect">>,
-                <<"answer">> => #{
-                    <<"url">> => Url,
-                    <<"source">> => Source,
-                    <<"query">> => Query
-                }
-            }
-        ]
+        <<"source">> => <<"redirect">>,
+        <<"type">> => <<"redirect">>,
+        <<"answer">> => #{
+            <<"url">> => Url,
+            <<"source">> => Source,
+            <<"query">> => Query
+        }
     }.
 
 %% ============================================================================
@@ -59,19 +56,13 @@ result(Question, Query, Source, Url) ->
 %% ============================================================================
 
 ddg(_) ->
-    Question = "ddg hello",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    Response = rinseweb_test:decode_response_body(ResponseBody),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"hello">>, <<"DuckDuckGo">>, <<"https://duckduckgo.com/?t=rinseone&q=hello">>),
-    ExpectedResponse = Response,
+    Answer = rinseweb_test:request_and_decode_answer("ddg hello"),
+    ExpectedAnswer = expected_answer(<<"hello">>, <<"DuckDuckGo">>, <<"https://duckduckgo.com/?t=rinseone&q=hello">>),
+    ExpectedAnswer = Answer,
     ok.
 
 ddg_encode_query(_) ->
-    Question = "ddg hello & goodbye",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    Response = rinseweb_test:decode_response_body(ResponseBody),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"hello & goodbye">>, <<"DuckDuckGo">>, <<"https://duckduckgo.com/?t=rinseone&q=hello%20%26%20goodbye">>),
-    ExpectedResponse = Response,
+    Answer = rinseweb_test:request_and_decode_answer("ddg hello & goodbye"),
+    ExpectedAnswer = expected_answer(<<"hello & goodbye">>, <<"DuckDuckGo">>, <<"https://duckduckgo.com/?t=rinseone&q=hello%20%26%20goodbye">>),
+    ExpectedAnswer = Answer,
     ok.

--- a/test/rinseweb_test.erl
+++ b/test/rinseweb_test.erl
@@ -3,6 +3,8 @@
 %% API
 -export([base_uri/0]).
 -export([question_uri/1]).
+-export([request_and_decode_answer/1]).
+-export([request_and_decode_answer/2]).
 -export([request_json/1]).
 -export([request_json/2]).
 -export([decode_response_body/1]).
@@ -17,6 +19,20 @@ base_uri() ->
 
 question_uri(Question) ->
      base_uri() ++ "/answer/" ++ edoc_lib:escape_uri(Question).
+
+request_and_decode_answer(Question) ->
+    request_and_decode_answer(Question, []).
+
+request_and_decode_answer(Question, ExtraHeaders) ->
+    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = request_json(Question, ExtraHeaders),
+    true = lists:member({"content-type","application/json"}, Headers),
+    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
+    ExpectedQuestion = rinseweb_util:binary_trim(list_to_binary(Question)),
+    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
+    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    true = is_map(Answer),
+    true = maps:is_key(<<"type">>, Answer),
+    Answer.
 
 request_json(Question) ->
     request_json(Question, []).

--- a/test/rinseweb_test.erl
+++ b/test/rinseweb_test.erl
@@ -2,12 +2,8 @@
 
 %% API
 -export([base_uri/0]).
--export([question_uri/1]).
 -export([request_and_decode_answer/1]).
 -export([request_and_decode_answer/2]).
--export([request_json/1]).
--export([request_json/2]).
--export([decode_response_body/1]).
 
 %%====================================================================
 %% API
@@ -17,16 +13,13 @@ base_uri() ->
     Port = integer_to_list(rinseweb_env:port()),
     "http://localhost:" ++ Port.
 
-question_uri(Question) ->
-     base_uri() ++ "/answer/" ++ edoc_lib:escape_uri(Question).
-
 request_and_decode_answer(Question) ->
     request_and_decode_answer(Question, []).
 
 request_and_decode_answer(Question, ExtraHeaders) ->
     {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = request_json(Question, ExtraHeaders),
     true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
+    ResponseMap = decode_response_body(ResponseBody),
     ExpectedQuestion = rinseweb_util:binary_trim(list_to_binary(Question)),
     ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
     [Answer|_] = maps:get(<<"answers">>, ResponseMap),
@@ -34,8 +27,12 @@ request_and_decode_answer(Question, ExtraHeaders) ->
     true = maps:is_key(<<"type">>, Answer),
     Answer.
 
-request_json(Question) ->
-    request_json(Question, []).
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+question_uri(Question) ->
+     base_uri() ++ "/answer/" ++ edoc_lib:escape_uri(Question).
 
 request_json(Question, ExtraHeaders) ->
     Headers = [{"Accept", "application/json"}|ExtraHeaders],

--- a/test/timestamp_web_SUITE.erl
+++ b/test/timestamp_web_SUITE.erl
@@ -42,18 +42,13 @@ end_per_testcase(_, _Config) ->
 %% Helpers
 %% ============================================================================
 
-result(Question, Text) ->
+expected_answer(Text) ->
     #{
-        <<"question">> => list_to_binary(Question),
-        <<"answers">> => [
-            #{
-                <<"source">> => <<"timestamp">>,
-                <<"type">> => <<"text">>,
-                <<"answer">> => #{
-                    <<"text">> => Text
-                }
-            }
-        ]
+        <<"source">> => <<"timestamp">>,
+        <<"type">> => <<"text">>,
+        <<"answer">> => #{
+            <<"text">> => Text
+        }
     }.
 
 %% ============================================================================
@@ -61,34 +56,22 @@ result(Question, Text) ->
 %% ============================================================================
 
 seconds(_) ->
-    Question = "1624433430",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    Response = rinseweb_test:decode_response_body(ResponseBody),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"2021-06-23 07:30:30 UTC">>),
-    ExpectedResponse = Response,
+    Answer = rinseweb_test:request_and_decode_answer("1624433430"),
+    ExpectedAnswer = expected_answer(<<"2021-06-23 07:30:30 UTC">>),
+    ExpectedAnswer = Answer,
     ok.
 
 milliseconds(_) ->
-    Question = "1624433430000",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    Response = rinseweb_test:decode_response_body(ResponseBody),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ExpectedResponse = result(Question, <<"2021-06-23 07:30:30 UTC">>),
-    ExpectedResponse = Response,
+    Answer = rinseweb_test:request_and_decode_answer("1624433430000"),
+    ExpectedAnswer = expected_answer(<<"2021-06-23 07:30:30 UTC">>),
+    ExpectedAnswer = Answer,
     ok.
 
 timestamp(_) ->
     TestStartTime = erlang:system_time(second),
     Questions = ["now", "timestamp", "unix timestamp"],
     F = fun(Question, Acc) ->
-            {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-            %[Answer|_] = rinseweb_test:decode_response_body(ResponseBody),
-            true = lists:member({"content-type","application/json"}, Headers),
-            ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-            ExpectedQuestion = list_to_binary(Question),
-            ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-            [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+            Answer = rinseweb_test:request_and_decode_answer(Question),
             <<"text">> = maps:get(<<"type">>, Answer),
             <<"timestamp">> = maps:get(<<"source">>, Answer),
             AnswerTimeBin = maps:get(<<"text">>, maps:get(<<"answer">>, Answer)),

--- a/test/uuid_web_SUITE.erl
+++ b/test/uuid_web_SUITE.erl
@@ -39,13 +39,7 @@ end_per_testcase(_, _Config) ->
 %% ============================================================================
 
 uuid_simple(_) ->
-    Question = "uuid",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    Answer = rinseweb_test:request_and_decode_answer("uuid"),
     <<"text">> = maps:get(<<"type">>, Answer),
     true = uuid:is_v4(uuid:string_to_uuid(maps:get(<<"text">>, maps:get(<<"answer">>, Answer)))),
     ok.

--- a/test/wikihow_web_SUITE.erl
+++ b/test/wikihow_web_SUITE.erl
@@ -39,13 +39,7 @@ end_per_testcase(_, _Config) ->
 %% ============================================================================
 
 search(_) ->
-    Question = "how do I say hello",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    Answer = rinseweb_test:request_and_decode_answer("how do I say hello"),
     <<"wiki">> = maps:get(<<"type">>, Answer),
     AnswerCustom = maps:get(<<"answer">>, Answer),
     true = is_list(AnswerCustom),

--- a/test/wikipedia_web_SUITE.erl
+++ b/test/wikipedia_web_SUITE.erl
@@ -39,13 +39,7 @@ end_per_testcase(_, _Config) ->
 %% ============================================================================
 
 search(_) ->
-    Question = "wiki hello",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    Answer = rinseweb_test:request_and_decode_answer("wiki hello"),
     <<"wiki">> = maps:get(<<"type">>, Answer),
     AnswerCustom = maps:get(<<"answer">>, Answer),
     true = is_list(AnswerCustom),

--- a/test/wimip_web_SUITE.erl
+++ b/test/wimip_web_SUITE.erl
@@ -45,13 +45,7 @@ end_per_testcase(_, _Config) ->
 %% ============================================================================
 
 simple(_) ->
-    Question = "wimip",
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    Answer = rinseweb_test:request_and_decode_answer("wimip"),
     <<"text">> = maps:get(<<"type">>, Answer),
     IpAddressBin = maps:get(<<"text">>, maps:get(<<"answer">>, Answer)),
     {ok, IpAddress} = inet:parse_address(binary_to_list(IpAddressBin)),
@@ -60,14 +54,7 @@ simple(_) ->
     ok.
 
 x_forwarded_for_empty(_) ->
-    Question = "wimip",
-    ExtraHeaders = [{"X-Forwarded-For", ""}],
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question, ExtraHeaders),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    Answer = rinseweb_test:request_and_decode_answer("wimip", [{"X-Forwarded-For", ""}]),
     <<"text">> = maps:get(<<"type">>, Answer),
     IpAddressBin = maps:get(<<"text">>, maps:get(<<"answer">>, Answer)),
     {ok, IpAddress} = inet:parse_address(binary_to_list(IpAddressBin)),
@@ -76,15 +63,9 @@ x_forwarded_for_empty(_) ->
     ok.
 
 x_forwarded_for_ipv4(_) ->
-    Question = "wimip",
     IpAddressReqBin = <<"1.2.3.4">>,
     ExtraHeaders = [{"X-Forwarded-For", binary_to_list(IpAddressReqBin)}],
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question, ExtraHeaders),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    Answer = rinseweb_test:request_and_decode_answer("wimip", ExtraHeaders),
     <<"text">> = maps:get(<<"type">>, Answer),
     IpAddressBin = maps:get(<<"text">>, maps:get(<<"answer">>, Answer)),
     IpAddressReqBin = IpAddressBin,
@@ -93,15 +74,9 @@ x_forwarded_for_ipv4(_) ->
     ok.
 
 x_forwarded_for_ipv6(_) ->
-    Question = "wimip",
     IpAddressReqBin = <<"2001:db8::2:1">>,
     ExtraHeaders = [{"X-Forwarded-For", binary_to_list(IpAddressReqBin)}],
-    {ok, {{"HTTP/1.1", 200, "OK"}, Headers, ResponseBody}} = rinseweb_test:request_json(Question, ExtraHeaders),
-    true = lists:member({"content-type","application/json"}, Headers),
-    ResponseMap = rinseweb_test:decode_response_body(ResponseBody),
-    ExpectedQuestion = list_to_binary(Question),
-    ExpectedQuestion = maps:get(<<"question">>, ResponseMap),
-    [Answer|_] = maps:get(<<"answers">>, ResponseMap),
+    Answer = rinseweb_test:request_and_decode_answer("wimip", ExtraHeaders),
     <<"text">> = maps:get(<<"type">>, Answer),
     IpAddressBin = maps:get(<<"text">>, maps:get(<<"answer">>, Answer)),
     IpAddressReqBin = IpAddressBin,


### PR DESCRIPTION
## Description

Moves repetitive checks and logic from web test suites to a central place in the helper `rinseweb_test` module.